### PR TITLE
add missing convenience methods for commands returning two or three events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 build
 
 .idea
+
+/xesar-connect/src/test/kotlin/realsystem/

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/Topics.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/Topics.kt
@@ -28,6 +28,30 @@ class Topics(vararg val topics: String) {
                 return "xs3/1/$userId/LoggedIn"
             }
 
+            /** MQTT topic string from the "AuthorizationProfileChanged" event. */
+            val AUTHORIZATION_PROFILE_CHANGED = "xs3/1/ces/AuthorizationProfileChanged"
+
+            /** MQTT topic string from the "AuthorizationProfileAccessChanged" event. */
+            val AUTHORIZATION_PROFILE_ACCESS_CHANGED = "xs3/1/ces/AuthorizationProfileAccessChanged"
+
+            /** MQTT topic string from the "AuthorizationProfileInfoChanged" event. */
+            val AUTHORIZATION_PROFILE_INFO_CHANGED = "xs3/1/ces/AuthorizationProfileInfoChanged"
+
+            /** MQTT topic string from the "MediumAddedToInstallation" event. */
+            val MEDIUM_ADDED_TO_INSTALLATION = "xs3/1/ces/MediumAddedToInstallation"
+
+            /** MQTT topic string from the "AddMediumToInstallationRequested" event. */
+            val ADD_MEDIUM_TO_INSTALLATION_REQUESTED = "xs3/1/ces/AddMediumToInstallationRequested"
+
+            /** MQTT topic string from the "InstallationPointCreated" event. */
+            val INSTALLATION_POINT_CREATED = "xs3/1/ces/InstallationPointCreated"
+
+            /** MQTT topic string from the "MediumAuthorizationProfileChanged" event. */
+            val MEDIUM_AUTHORIZATION_PROFILE_CHANGED = "xs3/1/ces/MediumAuthorizationProfileChanged"
+
+            /** MQTT topic string from the "EvvaComponentAdded" event. */
+            val EVVA_COMPONENT_ADDED = "xs3/1/ces/EvvaComponentAdded"
+
             /** MQTT topic string from the "AuthorizationProfileWithdrawnFromMedium" event. */
             val AUTHORIZATION_PROFILE_WITHDRAWN_FROM_MEDIUM =
                 "xs3/1/ces/AuthorizationProfileWithdrawnFromMedium"
@@ -145,6 +169,9 @@ class Topics(vararg val topics: String) {
             /** MQTT topic string for the "AuthorizationProfileCreated" event */
             val AUTHORIZATION_PROFILE_CREATED = "xs3/1/ces/AuthorizationProfileCreated"
 
+            /** MQTT topic string for the "AuthorizationTimeProfileChanged" event */
+            val AUTHORIZATION_TIME_PROFILE_CHANGED = "xs3/1/ces/AuthorizationTimeProfileChanged"
+
             /**
              * Generates the MQTT topic string which emits errors for previously received queries or
              * commands.
@@ -161,6 +188,23 @@ class Topics(vararg val topics: String) {
     class Command {
 
         companion object {
+
+            /** MQTT topic string for the "ChangeAuthorizationProfileMapi" command. */
+            val CHANGE_AUTHORIZATION_PROFILE = "xs3/1/cmd/ChangeAuthorizationProfileMapi"
+
+            /** MQTT topic string for the "RequestAddMediumToInstallationMapi" command. */
+            val REQUEST_ADD_MEDIUM_TO_INSTALLATION = "xs3/1/cmd/RequestAddMediumToInstallationMapi"
+
+            /** MQTT topic string for the "CreateInstallationPointMapi" command. */
+            val CREATE_INSTALLATION_POINT = "xs3/1/cmd/CreateInstallationPointMapi"
+
+            /** MQTT topic string for the "AssignAuthorizationProfileToMediumMapi" command. */
+            val ASSIGN_AUTHORIZATION_PROFILE_TO_MEDIUM =
+                "xs3/1/cmd/AssignAuthorizationProfileToMediumMapi"
+
+            /** MQTT topic string for the "AddEvvaComponentMapi" command. */
+            val ADD_EVVA_COMPONENT = "xs3/1/cmd/AddEvvaComponentMapi"
+
             /** MQTT topic string for the "WithdrawAuthorizationProfileFromMediumMapi" command. */
             val WITHDRAW_AUTHORIZATION_PROFILE_FROM_MEDIUM =
                 "xs3/1/cmd/WithdrawAuthorizationProfileFromMediumMapi"

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/exception/OptionalEventException.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/exception/OptionalEventException.kt
@@ -1,0 +1,3 @@
+package com.open200.xesar.connect.exception
+
+class OptionalEventException(str: String, e: Throwable) : XesarApiException(str, e) {}

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/exception/RequiredEventException.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/exception/RequiredEventException.kt
@@ -1,0 +1,3 @@
+package com.open200.xesar.connect.exception
+
+class RequiredEventException(str: String, e: Throwable) : XesarApiException(str, e) {}

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/extension/XesarConnectCalendarExt.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/extension/XesarConnectCalendarExt.kt
@@ -2,6 +2,7 @@ package com.open200.xesar.connect.extension
 
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
+import com.open200.xesar.connect.messages.SingleEventResult
 import com.open200.xesar.connect.messages.command.ChangeCalendarMapi
 import com.open200.xesar.connect.messages.command.CreateCalendarMapi
 import com.open200.xesar.connect.messages.command.DeleteCalendarMapi
@@ -11,11 +12,9 @@ import com.open200.xesar.connect.messages.event.CalendarCreated
 import com.open200.xesar.connect.messages.event.CalendarDeleted
 import com.open200.xesar.connect.messages.query.Calendar
 import com.open200.xesar.connect.messages.query.QueryList
-import com.open200.xesar.connect.utils.LocalDateSerializer
 import java.time.LocalDate
 import java.util.*
 import kotlinx.coroutines.Deferred
-import kotlinx.serialization.Serializable
 
 /**
  * Queries the list of calendars asynchronously.
@@ -53,14 +52,16 @@ suspend fun XesarConnect.queryCalendarByIdAsync(
  * @param calendarId The ID of the calendar.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.createCalendar(
+suspend fun XesarConnect.createCalendarAsync(
     name: String,
-    specialDays: List<@Serializable(with = LocalDateSerializer::class) LocalDate> = emptyList(),
+    specialDays: List<LocalDate> = emptyList(),
     calendarId: UUID,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<CalendarCreated> {
-    return sendCommand<CreateCalendarMapi, CalendarCreated>(
+): SingleEventResult<CalendarCreated> {
+    return sendCommandAsync<CreateCalendarMapi, CalendarCreated>(
         Topics.Command.CREATE_CALENDAR,
+        Topics.Event.CALENDAR_CREATED,
+        true,
         CreateCalendarMapi(config.uuidGenerator.generateId(), name, specialDays, calendarId, token),
         requestConfig)
 }
@@ -73,14 +74,16 @@ suspend fun XesarConnect.createCalendar(
  * @param specialDays The new list of special days.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.changeCalendar(
+suspend fun XesarConnect.changeCalendarAsync(
     calendarId: UUID,
     calendarName: String,
     specialDays: List<LocalDate> = emptyList(),
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<CalendarChanged> {
-    return sendCommand<ChangeCalendarMapi, CalendarChanged>(
+): SingleEventResult<CalendarChanged> {
+    return sendCommandAsync<ChangeCalendarMapi, CalendarChanged>(
         Topics.Command.CHANGE_CALENDAR,
+        Topics.Event.CALENDAR_CHANGED,
+        true,
         ChangeCalendarMapi(
             config.uuidGenerator.generateId(), calendarName, specialDays, calendarId, token),
         requestConfig)
@@ -92,12 +95,14 @@ suspend fun XesarConnect.changeCalendar(
  * @param calendarId The ID of the calendar to delete.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.deleteCalendar(
+suspend fun XesarConnect.deleteCalendarAsync(
     calendarId: UUID,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<CalendarDeleted> {
-    return sendCommand<DeleteCalendarMapi, CalendarDeleted>(
+): SingleEventResult<CalendarDeleted> {
+    return sendCommandAsync<DeleteCalendarMapi, CalendarDeleted>(
         Topics.Command.DELETE_CALENDAR,
+        Topics.Event.CALENDAR_DELETED,
+        true,
         DeleteCalendarMapi(config.uuidGenerator.generateId(), calendarId, token),
         requestConfig)
 }

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/extension/XesarConnectCodingStationExt.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/extension/XesarConnectCodingStationExt.kt
@@ -2,6 +2,7 @@ package com.open200.xesar.connect.extension
 
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
+import com.open200.xesar.connect.messages.SingleEventResult
 import com.open200.xesar.connect.messages.command.ChangeCodingStationMapi
 import com.open200.xesar.connect.messages.command.CreateCodingStationMapi
 import com.open200.xesar.connect.messages.command.DeleteCodingStationMapi
@@ -50,14 +51,16 @@ suspend fun XesarConnect.queryCodingStationByIdAsync(
  * @param codingStationId The ID of the coding station.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.createCodingStation(
+suspend fun XesarConnect.createCodingStationAsync(
     name: String,
     description: String? = null,
     codingStationId: UUID,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<CodingStationCreated> {
-    return sendCommand<CreateCodingStationMapi, CodingStationCreated>(
+): SingleEventResult<CodingStationCreated> {
+    return sendCommandAsync<CreateCodingStationMapi, CodingStationCreated>(
         Topics.Command.CREATE_CODING_STATION,
+        Topics.Event.CODING_STATION_CREATED,
+        true,
         CreateCodingStationMapi(
             config.uuidGenerator.generateId(), name, description, codingStationId, token),
         requestConfig)
@@ -71,14 +74,16 @@ suspend fun XesarConnect.createCodingStation(
  * @param description The description of the coding station (optional).
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.changeCodingStation(
+suspend fun XesarConnect.changeCodingStationAsync(
     codingStationId: UUID,
     name: String? = null,
     description: String? = null,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<CodingStationChanged> {
-    return sendCommand<ChangeCodingStationMapi, CodingStationChanged>(
+): SingleEventResult<CodingStationChanged> {
+    return sendCommandAsync<ChangeCodingStationMapi, CodingStationChanged>(
         Topics.Command.CHANGE_CODING_STATION,
+        Topics.Event.CODING_STATION_CHANGED,
+        true,
         ChangeCodingStationMapi(
             config.uuidGenerator.generateId(), codingStationId, name, description, token),
         requestConfig)
@@ -90,12 +95,14 @@ suspend fun XesarConnect.changeCodingStation(
  * @param codingStationId The ID of the coding station.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.deleteCodingStation(
+suspend fun XesarConnect.deleteCodingStationAsync(
     codingStationId: UUID,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<CodingStationDeleted> {
-    return sendCommand<DeleteCodingStationMapi, CodingStationDeleted>(
+): SingleEventResult<CodingStationDeleted> {
+    return sendCommandAsync<DeleteCodingStationMapi, CodingStationDeleted>(
         Topics.Command.DELETE_CODING_STATION,
+        Topics.Event.CODING_STATION_DELETED,
+        true,
         DeleteCodingStationMapi(config.uuidGenerator.generateId(), codingStationId, token),
         requestConfig)
 }

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/extension/XesarConnectIdentificationMediumExt.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/extension/XesarConnectIdentificationMediumExt.kt
@@ -3,7 +3,10 @@ package com.open200.xesar.connect.extension
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.exception.MediumListSizeException
+import com.open200.xesar.connect.messages.AssignAuthorizationProfileToMediumResult
 import com.open200.xesar.connect.messages.DisengagePeriod
+import com.open200.xesar.connect.messages.RequestAddMediumToInstallationResult
+import com.open200.xesar.connect.messages.SingleEventResult
 import com.open200.xesar.connect.messages.command.*
 import com.open200.xesar.connect.messages.event.*
 import com.open200.xesar.connect.messages.query.IdentificationMedium
@@ -97,14 +100,16 @@ suspend fun XesarConnect.queryIdentificationMediumByMediumIdentifierAsync(
  * @param authorization The authorization to add.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.addInstallationPointAuthorizationToMedium(
+suspend fun XesarConnect.addInstallationPointAuthorizationToMediumAsync(
     mediumId: UUID,
     authorization: AuthorizationData,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<IndividualAuthorizationsAddedToMedium> {
-    return sendCommand<
+): SingleEventResult<IndividualAuthorizationsAddedToMedium> {
+    return sendCommandAsync<
         AddInstallationPointAuthorizationToMediumMapi, IndividualAuthorizationsAddedToMedium>(
         Topics.Command.ADD_INSTALLATION_POINT_AUTHORIZATION_TO_MEDIUM,
+        Topics.Event.INDIVIDUAL_AUTHORIZATIONS_ADDED_TO_MEDIUM,
+        true,
         AddInstallationPointAuthorizationToMediumMapi(
             config.uuidGenerator.generateId(), mediumId, authorization, token),
         requestConfig)
@@ -117,13 +122,16 @@ suspend fun XesarConnect.addInstallationPointAuthorizationToMedium(
  * @param authorizationData The authorization to add.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.addZoneAuthorizationToMedium(
+suspend fun XesarConnect.addZoneAuthorizationToMediumAsync(
     mediumId: UUID,
     authorizationData: AuthorizationData,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<IndividualAuthorizationsAddedToMedium> {
-    return sendCommand<AddZoneAuthorizationToMediumMapi, IndividualAuthorizationsAddedToMedium>(
+): SingleEventResult<IndividualAuthorizationsAddedToMedium> {
+    return sendCommandAsync<
+        AddZoneAuthorizationToMediumMapi, IndividualAuthorizationsAddedToMedium>(
         Topics.Command.ADD_ZONE_AUTHORIZATION_TO_MEDIUM,
+        Topics.Event.INDIVIDUAL_AUTHORIZATIONS_ADDED_TO_MEDIUM,
+        true,
         AddZoneAuthorizationToMediumMapi(
             config.uuidGenerator.generateId(), mediumId, authorizationData, token),
         requestConfig)
@@ -135,13 +143,15 @@ suspend fun XesarConnect.addZoneAuthorizationToMedium(
  * @param personId The ID of the person to assign.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.assignPersonToMedium(
+suspend fun XesarConnect.assignPersonToMediumAsync(
     mediumId: UUID,
     personId: UUID,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<MediumPersonChanged> {
-    return sendCommand<AssignPersonToMediumMapi, MediumPersonChanged>(
+): SingleEventResult<MediumPersonChanged> {
+    return sendCommandAsync<AssignPersonToMediumMapi, MediumPersonChanged>(
         Topics.Command.ASSIGN_PERSON_TO_MEDIUM,
+        Topics.Event.MEDIUM_PERSON_CHANGED,
+        true,
         AssignPersonToMediumMapi(config.uuidGenerator.generateId(), mediumId, personId, token),
         requestConfig)
 }
@@ -152,12 +162,14 @@ suspend fun XesarConnect.assignPersonToMedium(
  * @param mediumId The ID of the medium to lock.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.lockMedium(
+suspend fun XesarConnect.lockMediumAsync(
     mediumId: UUID,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<MediumLocked> {
-    return sendCommand<LockMediumMapi, MediumLocked>(
+): SingleEventResult<MediumLocked> {
+    return sendCommandAsync<LockMediumMapi, MediumLocked>(
         Topics.Command.LOCK_MEDIUM,
+        Topics.Event.MEDIUM_LOCKED,
+        true,
         LockMediumMapi(config.uuidGenerator.generateId(), mediumId, token),
         requestConfig)
 }
@@ -169,14 +181,16 @@ suspend fun XesarConnect.lockMedium(
  * @param installationPointAuthorization The installation point id.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.removeInstallationPointAuthorizationFromMedium(
+suspend fun XesarConnect.removeInstallationPointAuthorizationFromMediumAsync(
     mediumId: UUID,
     installationPointAuthorization: UUID,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<IndividualAuthorizationsDeleted> {
-    return sendCommand<
+): SingleEventResult<IndividualAuthorizationsDeleted> {
+    return sendCommandAsync<
         RemoveInstallationPointAuthorizationFromMediumMapi, IndividualAuthorizationsDeleted>(
         Topics.Command.REMOVE_INSTALLATION_POINT_AUTHORIZATION_FROM_MEDIUM,
+        Topics.Event.INDIVIDUAL_AUTHORIZATIONS_DELETED,
+        true,
         RemoveInstallationPointAuthorizationFromMediumMapi(
             config.uuidGenerator.generateId(), installationPointAuthorization, mediumId, token),
         requestConfig)
@@ -188,13 +202,15 @@ suspend fun XesarConnect.removeInstallationPointAuthorizationFromMedium(
  * @param zoneAuthorization The zone id.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.removeZoneAuthorizationFromMedium(
+suspend fun XesarConnect.removeZoneAuthorizationFromMediumAsync(
     mediumId: UUID,
     zoneAuthorization: UUID,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<IndividualAuthorizationsDeleted> {
-    return sendCommand<RemoveZoneAuthorizationFromMediumMapi, IndividualAuthorizationsDeleted>(
+): SingleEventResult<IndividualAuthorizationsDeleted> {
+    return sendCommandAsync<RemoveZoneAuthorizationFromMediumMapi, IndividualAuthorizationsDeleted>(
         Topics.Command.REMOVE_ZONE_AUTHORIZATION_FROM_MEDIUM,
+        Topics.Event.INDIVIDUAL_AUTHORIZATIONS_DELETED,
+        true,
         RemoveZoneAuthorizationFromMediumMapi(
             config.uuidGenerator.generateId(), zoneAuthorization, mediumId, token),
         requestConfig)
@@ -207,13 +223,15 @@ suspend fun XesarConnect.removeZoneAuthorizationFromMedium(
  * @param accessBeginAt The access begin to set.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.setAccessBeginAt(
+suspend fun XesarConnect.setAccessBeginAtAsync(
     mediumId: UUID,
     accessBeginAt: LocalDateTime,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<MediumChanged> {
-    return sendCommand<SetAccessBeginAtMapi, MediumChanged>(
+): SingleEventResult<MediumChanged> {
+    return sendCommandAsync<SetAccessBeginAtMapi, MediumChanged>(
         Topics.Command.SET_ACCESS_BEGIN_AT,
+        Topics.Event.MEDIUM_CHANGED,
+        true,
         SetAccessBeginAtMapi(config.uuidGenerator.generateId(), accessBeginAt, mediumId, token),
         requestConfig)
 }
@@ -224,13 +242,15 @@ suspend fun XesarConnect.setAccessBeginAt(
  * @param accessEndAt The access end to set.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.setAccessEndAt(
+suspend fun XesarConnect.setAccessEndAtAsync(
     mediumId: UUID,
     accessEndAt: LocalDateTime? = null,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<MediumChanged> {
-    return sendCommand<SetAccessEndAtMapi, MediumChanged>(
+): SingleEventResult<MediumChanged> {
+    return sendCommandAsync<SetAccessEndAtMapi, MediumChanged>(
         Topics.Command.SET_ACCESS_END_AT,
+        Topics.Event.MEDIUM_CHANGED,
+        true,
         SetAccessEndAtMapi(config.uuidGenerator.generateId(), accessEndAt, mediumId, token),
         requestConfig)
 }
@@ -242,13 +262,15 @@ suspend fun XesarConnect.setAccessEndAt(
  * @param disengagePeriod The disengage period to set.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.setDisengagePeriodOnMedium(
+suspend fun XesarConnect.setDisengagePeriodOnMediumAsync(
     mediumId: UUID,
     disengagePeriod: DisengagePeriod,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<MediumChanged> {
-    return sendCommand<SetDisengagePeriodOnMediumMapi, MediumChanged>(
+): SingleEventResult<MediumChanged> {
+    return sendCommandAsync<SetDisengagePeriodOnMediumMapi, MediumChanged>(
         Topics.Command.SET_DISENGAGE_PERIOD_ON_MEDIUM,
+        Topics.Event.MEDIUM_CHANGED,
+        true,
         SetDisengagePeriodOnMediumMapi(
             config.uuidGenerator.generateId(), disengagePeriod, mediumId, token),
         requestConfig)
@@ -260,13 +282,15 @@ suspend fun XesarConnect.setDisengagePeriodOnMedium(
  * @param label The label to set.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.setLabelOnMedium(
+suspend fun XesarConnect.setLabelOnMediumAsync(
     mediumId: UUID,
     label: String,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<MediumChanged> {
-    return sendCommand<SetLabelOnMediumMapi, MediumChanged>(
+): SingleEventResult<MediumChanged> {
+    return sendCommandAsync<SetLabelOnMediumMapi, MediumChanged>(
         Topics.Command.SET_LABEL_ON_MEDIUM,
+        Topics.Event.MEDIUM_CHANGED,
+        true,
         SetLabelOnMediumMapi(config.uuidGenerator.generateId(), mediumId, label, token),
         requestConfig)
 }
@@ -277,13 +301,15 @@ suspend fun XesarConnect.setLabelOnMedium(
  * @param validityDuration The validity duration to set.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.setValidityDuration(
+suspend fun XesarConnect.setValidityDurationAsync(
     mediumId: UUID,
     validityDuration: Short,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<MediumChanged> {
-    return sendCommand<SetValidityDurationMapi, MediumChanged>(
+): SingleEventResult<MediumChanged> {
+    return sendCommandAsync<SetValidityDurationMapi, MediumChanged>(
         Topics.Command.SET_VALIDITY_DURATION,
+        Topics.Event.MEDIUM_CHANGED,
+        true,
         SetValidityDurationMapi(
             config.uuidGenerator.generateId(), validityDuration, mediumId, token),
         requestConfig)
@@ -299,15 +325,86 @@ suspend fun XesarConnect.setValidityDuration(
  * @param authorizationProfileId The ID of the authorization profile to withdraw.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.withdrawAuthorizationProfileFromMedium(
+suspend fun XesarConnect.withdrawAuthorizationProfileFromMediumAsync(
     mediumId: UUID,
     authorizationProfileId: UUID? = null,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<AuthorizationProfileWithdrawnFromMedium> {
-    return sendCommand<
+): SingleEventResult<AuthorizationProfileWithdrawnFromMedium> {
+    return sendCommandAsync<
         WithdrawAuthorizationProfileFromMediumMapi, AuthorizationProfileWithdrawnFromMedium>(
         Topics.Command.WITHDRAW_AUTHORIZATION_PROFILE_FROM_MEDIUM,
+        Topics.Event.AUTHORIZATION_PROFILE_WITHDRAWN_FROM_MEDIUM,
+        true,
         WithdrawAuthorizationProfileFromMediumMapi(
             config.uuidGenerator.generateId(), authorizationProfileId, mediumId, token),
         requestConfig)
+}
+/**
+ * Assigns an authorization profile to a medium asynchronously.
+ *
+ * @param mediumId The ID of the medium to assign the authorization profile to.
+ * @param authorizationProfileId The ID of the authorization profile to assign.
+ * @param requestConfig The request configuration (optional).
+ */
+suspend fun XesarConnect.assignAuthorizationProfileToMediumAsync(
+    mediumId: UUID,
+    authorizationProfileId: UUID? = null,
+    requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
+): AssignAuthorizationProfileToMediumResult {
+    val commandId = config.uuidGenerator.generateId()
+    val assignAuthorizationProfileToMediumResult =
+        sendCommandAsync<
+            AssignAuthorizationProfileToMediumMapi,
+            MediumChanged,
+            MediumAuthorizationProfileChanged>(
+            Topics.Command.ASSIGN_AUTHORIZATION_PROFILE_TO_MEDIUM,
+            Topics.Event.MEDIUM_CHANGED,
+            false,
+            Topics.Event.MEDIUM_AUTHORIZATION_PROFILE_CHANGED,
+            false,
+            AssignAuthorizationProfileToMediumMapi(
+                commandId, authorizationProfileId, mediumId, token),
+            requestConfig)
+
+    return AssignAuthorizationProfileToMediumResult(
+        assignAuthorizationProfileToMediumResult.first,
+        assignAuthorizationProfileToMediumResult.second,
+        assignAuthorizationProfileToMediumResult.third)
+}
+/**
+ * Requests to add a medium to an installation asynchronously.
+ *
+ * @param mediumId The ID of the medium to add to the installation.
+ * @param hardwareId The hardware ID of the medium to add to the installation.
+ * @param terminalId The ID of the terminal to add the medium to.
+ * @param label The label of the medium to add to the installation (optional).
+ * @param requestConfig The request configuration (optional).
+ * @return A deferred object that resolves to the result of the request to add a medium to an
+ *   installation.
+ */
+suspend fun XesarConnect.requestToAddMediumToInstallationAsync(
+    mediumId: UUID,
+    hardwareId: String,
+    terminalId: UUID,
+    label: String? = null,
+    requestConfig: XesarConnect.RequestConfig = buildRequestConfig(),
+): RequestAddMediumToInstallationResult {
+    val commandId = config.uuidGenerator.generateId()
+    val requestAddMediumToInstallationResult =
+        sendCommandAsync<
+            RequestAddMediumToInstallationMapi,
+            AddMediumToInstallationRequested,
+            MediumAddedToInstallation>(
+            Topics.Command.REQUEST_ADD_MEDIUM_TO_INSTALLATION,
+            Topics.Event.ADD_MEDIUM_TO_INSTALLATION_REQUESTED,
+            true,
+            Topics.Event.MEDIUM_ADDED_TO_INSTALLATION,
+            true,
+            RequestAddMediumToInstallationMapi(
+                hardwareId, mediumId, terminalId, label, commandId, token),
+            requestConfig)
+    return RequestAddMediumToInstallationResult(
+        requestAddMediumToInstallationResult.first,
+        requestAddMediumToInstallationResult.second,
+        requestAddMediumToInstallationResult.third)
 }

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/extension/XesarConnectInstallationPointExt.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/extension/XesarConnectInstallationPointExt.kt
@@ -2,13 +2,17 @@ package com.open200.xesar.connect.extension
 
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
+import com.open200.xesar.connect.messages.AddEvvaComponentResult
+import com.open200.xesar.connect.messages.ComponentType
+import com.open200.xesar.connect.messages.CreateInstallationPointResult
 import com.open200.xesar.connect.messages.PersonalLog
+import com.open200.xesar.connect.messages.SingleEventResult
 import com.open200.xesar.connect.messages.command.*
 import com.open200.xesar.connect.messages.event.*
 import com.open200.xesar.connect.messages.query.InstallationPoint
 import com.open200.xesar.connect.messages.query.QueryList
 import java.util.*
-import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.*
 
 /**
  * Queries the list of installation points asynchronously.
@@ -45,13 +49,15 @@ suspend fun XesarConnect.queryInstallationPointByIdAsync(
  * @param enable Enable or disable the beeping signal
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.findComponent(
+suspend fun XesarConnect.findComponentAsync(
     installationPointId: UUID,
     enable: Boolean? = null,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<FindComponentPerformed> {
-    return sendCommand<FindComponent, FindComponentPerformed>(
+): SingleEventResult<FindComponentPerformed> {
+    return sendCommandAsync<FindComponent, FindComponentPerformed>(
         Topics.Command.FIND_COMPONENT,
+        Topics.Event.FIND_COMPONENT_PERFORMED,
+        true,
         FindComponent(config.uuidGenerator.generateId(), installationPointId, enable, token),
         requestConfig)
 }
@@ -63,13 +69,15 @@ suspend fun XesarConnect.findComponent(
  * @param extended false for SHORT / true for LONG disengage
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.executeRemoteDisengage(
+suspend fun XesarConnect.executeRemoteDisengageAsync(
     installationPointId: UUID,
     extended: Boolean? = null,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<RemoteDisengagePerformed> {
-    return sendCommand<RemoteDisengage, RemoteDisengagePerformed>(
+): SingleEventResult<RemoteDisengagePerformed> {
+    return sendCommandAsync<RemoteDisengage, RemoteDisengagePerformed>(
         Topics.Command.REMOTE_DISENGAGE,
+        Topics.Event.REMOTE_DISENGAGE_PERFORMED,
+        true,
         RemoteDisengage(config.uuidGenerator.generateId(), installationPointId, extended, token),
         requestConfig)
 }
@@ -81,13 +89,15 @@ suspend fun XesarConnect.executeRemoteDisengage(
  * @param enable Enable or disable the permanent disengage
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.executeRemoteDisengagePermanent(
+suspend fun XesarConnect.executeRemoteDisengagePermanentAsync(
     installationPointId: UUID,
     enable: Boolean? = null,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<RemoteDisengagePermanentPerformed> {
-    return sendCommand<RemoteDisengagePermanent, RemoteDisengagePermanentPerformed>(
+): SingleEventResult<RemoteDisengagePermanentPerformed> {
+    return sendCommandAsync<RemoteDisengagePermanent, RemoteDisengagePermanentPerformed>(
         Topics.Command.REMOTE_DISENGAGE_PERMANENT,
+        Topics.Event.REMOTE_DISENGAGE_PERMANENT_PERFORMED,
+        true,
         RemoteDisengagePermanent(
             config.uuidGenerator.generateId(), installationPointId, enable, token),
         requestConfig)
@@ -103,16 +113,18 @@ suspend fun XesarConnect.executeRemoteDisengagePermanent(
  * @param installationId The ID of the installation
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.changeInstallationPoint(
+suspend fun XesarConnect.changeInstallationPointAsync(
     installationPointId: UUID,
     installationType: String? = null,
     name: String? = null,
     description: String? = null,
     installationId: UUID? = null,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<InstallationPointChanged> {
-    return sendCommand<ChangeInstallationPointMapi, InstallationPointChanged>(
+): SingleEventResult<InstallationPointChanged> {
+    return sendCommandAsync<ChangeInstallationPointMapi, InstallationPointChanged>(
         Topics.Command.CHANGE_INSTALLATION_POINT,
+        Topics.Event.INSTALLATION_POINT_CHANGED,
+        true,
         ChangeInstallationPointMapi(
             config.uuidGenerator.generateId(),
             installationPointId,
@@ -132,21 +144,23 @@ suspend fun XesarConnect.changeInstallationPoint(
  * @param installationPointId The ID of the installation point
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.configureManualOfficeModeAndShopModeMapi(
+suspend fun XesarConnect.configureManualOfficeModeAndShopModeMapiAsync(
     shopMode: Boolean? = null,
     manualOfficeMode: Boolean? = null,
     installationPointId: UUID? = null,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<InstallationPointChanged> {
-    return sendCommand<ConfigureManualOfficeModeAndShopModeMapi, InstallationPointChanged>(
+): SingleEventResult<InstallationPointChanged> {
+    return sendCommandAsync<ConfigureManualOfficeModeAndShopModeMapi, InstallationPointChanged>(
         Topics.Command.CONFIGURE_MANUAL_OFFICE_MODE_AND_SHOP_MODE,
+        Topics.Event.INSTALLATION_POINT_CHANGED,
+        true,
         ConfigureManualOfficeModeAndShopModeMapi(
             config.uuidGenerator.generateId(),
             shopMode,
             manualOfficeMode,
             installationPointId,
             token),
-        buildRequestConfig())
+        requestConfig)
 }
 
 /**
@@ -156,13 +170,15 @@ suspend fun XesarConnect.configureManualOfficeModeAndShopModeMapi(
  * @param installationPointId The ID of the installation point
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.configureMediaUpgradeMapi(
+suspend fun XesarConnect.configureMediaUpgradeMapiAsync(
     upgradeMedia: Boolean? = null,
     installationPointId: UUID,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<InstallationPointChanged> {
-    return sendCommand<ConfigureMediaUpgradeMapi, InstallationPointChanged>(
+): SingleEventResult<InstallationPointChanged> {
+    return sendCommandAsync<ConfigureMediaUpgradeMapi, InstallationPointChanged>(
         Topics.Command.CONFIGURE_MEDIA_UPGRADE,
+        Topics.Event.INSTALLATION_POINT_CHANGED,
+        true,
         ConfigureMediaUpgradeMapi(
             config.uuidGenerator.generateId(), upgradeMedia, installationPointId, token),
         requestConfig)
@@ -175,13 +191,15 @@ suspend fun XesarConnect.configureMediaUpgradeMapi(
  * @param installationPointId The ID of the installation point
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.configureOfficeModeTimeProfile(
+suspend fun XesarConnect.configureOfficeModeTimeProfileAsync(
     officeModeTimeProfileId: UUID? = null,
     installationPointId: UUID,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<InstallationPointChanged> {
-    return sendCommand<ConfigureOfficeModeTimeProfileMapi, InstallationPointChanged>(
+): SingleEventResult<InstallationPointChanged> {
+    return sendCommandAsync<ConfigureOfficeModeTimeProfileMapi, InstallationPointChanged>(
         Topics.Command.CONFIGURE_OFFICE_MODE_TIME_PROFILE,
+        Topics.Event.INSTALLATION_POINT_CHANGED,
+        true,
         ConfigureOfficeModeTimeProfileMapi(
             config.uuidGenerator.generateId(), installationPointId, officeModeTimeProfileId, token),
         requestConfig)
@@ -197,14 +215,16 @@ suspend fun XesarConnect.configureOfficeModeTimeProfile(
  * @param installationPointId The installation point id.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.configureReleaseDuration(
+suspend fun XesarConnect.configureReleaseDurationAsync(
     releaseDurationShort: Int? = null,
     releaseDurationLong: Int? = null,
     installationPointId: UUID,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<InstallationPointChanged> {
-    return sendCommand<ConfigureReleaseDurationMapi, InstallationPointChanged>(
+): SingleEventResult<InstallationPointChanged> {
+    return sendCommandAsync<ConfigureReleaseDurationMapi, InstallationPointChanged>(
         Topics.Command.CONFIGURE_RELEASE_DURATION,
+        Topics.Event.INSTALLATION_POINT_CHANGED,
+        true,
         ConfigureReleaseDurationMapi(
             config.uuidGenerator.generateId(),
             releaseDurationShort,
@@ -220,14 +240,41 @@ suspend fun XesarConnect.configureReleaseDuration(
  * @param installationPointId The installation point id
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.deleteInstallationPoint(
+suspend fun XesarConnect.deleteInstallationPointAsync(
     installationPointId: UUID,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<InstallationPointDeleted> {
-    return sendCommand<DeleteInstallationPointMapi, InstallationPointDeleted>(
+): SingleEventResult<InstallationPointDeleted> {
+    return sendCommandAsync<DeleteInstallationPointMapi, InstallationPointDeleted>(
         Topics.Command.DELETE_INSTALLATION_POINT,
+        Topics.Event.INSTALLATION_POINT_DELETED,
+        true,
         DeleteInstallationPointMapi(config.uuidGenerator.generateId(), installationPointId, token),
         requestConfig)
+}
+/**
+ * Adds an EVVA component asynchronously.
+ *
+ * @param installationPointId The installation point id
+ * @param componentType The type of component to add
+ * @param requestConfig The request configuration (optional).
+ */
+suspend fun XesarConnect.addEvvaComponentAsync(
+    installationPointId: UUID,
+    componentType: ComponentType,
+    requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
+): AddEvvaComponentResult {
+    val commandId = config.uuidGenerator.generateId()
+    val addEvvaComponentResult =
+        sendCommandAsync<AddEvvaComponentMapi, InstallationPointChanged, EvvaComponentAdded>(
+            Topics.Command.ADD_EVVA_COMPONENT,
+            Topics.Event.INSTALLATION_POINT_CHANGED,
+            true,
+            Topics.Event.EVVA_COMPONENT_ADDED,
+            false,
+            AddEvvaComponentMapi(commandId, installationPointId, componentType, token),
+            requestConfig)
+    return AddEvvaComponentResult(
+        addEvvaComponentResult.first, addEvvaComponentResult.second, addEvvaComponentResult.third)
 }
 
 /**
@@ -236,12 +283,14 @@ suspend fun XesarConnect.deleteInstallationPoint(
  * @param installationPointId The installation point id
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.forceRemoveEvvaComponent(
+suspend fun XesarConnect.forceRemoveEvvaComponentAsync(
     installationPointId: UUID,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<EvvaComponentRemoved> {
-    return sendCommand<ForceRemoveEvvaComponentMapi, EvvaComponentRemoved>(
+): SingleEventResult<EvvaComponentRemoved> {
+    return sendCommandAsync<ForceRemoveEvvaComponentMapi, EvvaComponentRemoved>(
         Topics.Command.FORCE_REMOVE_EVVA_COMPONENT,
+        Topics.Event.EVVA_COMPONENT_REMOVED,
+        true,
         ForceRemoveEvvaComponentMapi(config.uuidGenerator.generateId(), installationPointId, token),
         requestConfig)
 }
@@ -251,12 +300,14 @@ suspend fun XesarConnect.forceRemoveEvvaComponent(
  * @param installationPointId The installation point id
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.prepareRemovalOfEvvaComponent(
+suspend fun XesarConnect.prepareRemovalOfEvvaComponentAsync(
     installationPointId: UUID,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<EvvaComponentRemovalPrepared> {
-    return sendCommand<PrepareRemovalOfEvvaComponentMapi, EvvaComponentRemovalPrepared>(
+): SingleEventResult<EvvaComponentRemovalPrepared> {
+    return sendCommandAsync<PrepareRemovalOfEvvaComponentMapi, EvvaComponentRemovalPrepared>(
         Topics.Command.PREPARE_REMOVAL_OF_EVVA_COMPONENT,
+        Topics.Event.EVVA_COMPONENT_REMOVAL_PREPARED,
+        true,
         PrepareRemovalOfEvvaComponentMapi(
             config.uuidGenerator.generateId(), installationPointId, token),
         requestConfig)
@@ -268,13 +319,15 @@ suspend fun XesarConnect.prepareRemovalOfEvvaComponent(
  * @param installationPointId The installation point id
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.revertPrepareRemovalOfEvvaComponent(
+suspend fun XesarConnect.revertPrepareRemovalOfEvvaComponentAsync(
     installationPointId: UUID,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<PrepareEvvaComponentRemovalReverted> {
-    return sendCommand<
+): SingleEventResult<PrepareEvvaComponentRemovalReverted> {
+    return sendCommandAsync<
         RevertPrepareRemovalOfEvvaComponentMapi, PrepareEvvaComponentRemovalReverted>(
         Topics.Command.REVERT_PREPARE_REMOVAL_OF_EVVA_COMPONENT,
+        Topics.Event.PREPARE_EVVA_COMPONENT_REMOVAL_REVERTED,
+        true,
         RevertPrepareRemovalOfEvvaComponentMapi(
             config.uuidGenerator.generateId(), installationPointId, token),
         requestConfig)
@@ -286,18 +339,53 @@ suspend fun XesarConnect.revertPrepareRemovalOfEvvaComponent(
  * @param personalReferenceDuration The personal reference duration
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.setPersonalReferenceDurationForInstallationPoint(
+suspend fun XesarConnect.setPersonalReferenceDurationForInstallationPointAsync(
     installationPointId: UUID,
     personalReferenceDuration: PersonalLog,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<InstallationPointChanged> {
-    return sendCommand<
+): SingleEventResult<InstallationPointChanged> {
+    return sendCommandAsync<
         SetPersonalReferenceDurationForInstallationPointMapi, InstallationPointChanged>(
         Topics.Command.SET_PERSONAL_REFERENCE_DURATION_FOR_INSTALLATION_POINT,
+        Topics.Event.INSTALLATION_POINT_CHANGED,
+        true,
         SetPersonalReferenceDurationForInstallationPointMapi(
             config.uuidGenerator.generateId(),
             personalReferenceDuration,
             installationPointId,
             token),
         requestConfig)
+}
+
+/**
+ * Creates an installation point asynchronously.
+ *
+ * @param componentType The type of component installed in the installation point.
+ * @param installationPointId The id of the installation point.
+ * @param linkedInstallationPoints A map consisting of the installation-point id as the key and the
+ *   properties as values. Use this if the installation point has more than one evva component (e.g.
+ *   the Evva component type 'WallReader2x').
+ * @param requestConfig The request configuration (optional).
+ */
+suspend fun XesarConnect.createInstallationPointAsync(
+    componentType: ComponentType,
+    installationPointId: UUID,
+    linkedInstallationPoints: Map<UUID, CreateInstallationPointMapi.Properties> = emptyMap(),
+    requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
+): CreateInstallationPointResult {
+    val commandId = config.uuidGenerator.generateId()
+    val createInstallationPointResult =
+        sendCommandAsync<CreateInstallationPointMapi, InstallationPointCreated, EvvaComponentAdded>(
+            Topics.Command.CREATE_INSTALLATION_POINT,
+            Topics.Event.INSTALLATION_POINT_CREATED,
+            true,
+            Topics.Event.EVVA_COMPONENT_ADDED,
+            false,
+            CreateInstallationPointMapi(
+                componentType, installationPointId, linkedInstallationPoints, commandId, token),
+            requestConfig)
+    return CreateInstallationPointResult(
+        createInstallationPointResult.first,
+        createInstallationPointResult.second,
+        createInstallationPointResult.third)
 }

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/extension/XesarConnectPartitionExt.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/extension/XesarConnectPartitionExt.kt
@@ -3,10 +3,10 @@ package com.open200.xesar.connect.extension
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.messages.PersonalLog
+import com.open200.xesar.connect.messages.SingleEventResult
 import com.open200.xesar.connect.messages.command.*
 import com.open200.xesar.connect.messages.event.PartitionChanged
 import java.time.LocalTime
-import kotlinx.coroutines.Deferred
 
 /**
  * Sets the daily scheduler execution time in the default partition asynchronously.
@@ -14,12 +14,14 @@ import kotlinx.coroutines.Deferred
  * @param dailySchedulerExecutionTime The time of day when the daily scheduler should be executed
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.setDailySchedulerExecutionTime(
+suspend fun XesarConnect.setDailySchedulerExecutionTimeAsync(
     dailySchedulerExecutionTime: LocalTime,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<PartitionChanged> {
-    return sendCommand<SetDailySchedulerExecutionTimeMapi, PartitionChanged>(
+): SingleEventResult<PartitionChanged> {
+    return sendCommandAsync<SetDailySchedulerExecutionTimeMapi, PartitionChanged>(
         Topics.Command.SET_DAILY_SCHEDULER_EXECUTION_TIME,
+        Topics.Event.PARTITION_CHANGED,
+        true,
         SetDailySchedulerExecutionTimeMapi(
             config.uuidGenerator.generateId(), dailySchedulerExecutionTime, token),
         requestConfig)
@@ -30,12 +32,14 @@ suspend fun XesarConnect.setDailySchedulerExecutionTime(
  * @param validityDuration The default validity duration
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.setDefaultValidityDuration(
+suspend fun XesarConnect.setDefaultValidityDurationAsync(
     validityDuration: Short,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<PartitionChanged> {
-    return sendCommand<SetDefaultValidityDurationMapi, PartitionChanged>(
+): SingleEventResult<PartitionChanged> {
+    return sendCommandAsync<SetDefaultValidityDurationMapi, PartitionChanged>(
         Topics.Command.SET_DEFAULT_VALIDITY_DURATION,
+        Topics.Event.PARTITION_CHANGED,
+        true,
         SetDefaultValidityDurationMapi(config.uuidGenerator.generateId(), validityDuration, token),
         requestConfig)
 }
@@ -47,12 +51,14 @@ suspend fun XesarConnect.setDefaultValidityDuration(
  * @param personalReferenceDuration The default personal reference duration
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.setInstallationPointPersonalReferenceDuration(
+suspend fun XesarConnect.setInstallationPointPersonalReferenceDurationAsync(
     personalReferenceDuration: PersonalLog,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<PartitionChanged> {
-    return sendCommand<SetInstallationPointPersonalReferenceDurationMapi, PartitionChanged>(
+): SingleEventResult<PartitionChanged> {
+    return sendCommandAsync<SetInstallationPointPersonalReferenceDurationMapi, PartitionChanged>(
         Topics.Command.SET_INSTALLATION_POINT_PERSONAL_REFERENCE_DURATION,
+        Topics.Event.PARTITION_CHANGED,
+        true,
         SetInstallationPointPersonalReferenceDurationMapi(
             config.uuidGenerator.generateId(), personalReferenceDuration, token),
         requestConfig)
@@ -64,12 +70,14 @@ suspend fun XesarConnect.setInstallationPointPersonalReferenceDuration(
  * @param personalReferenceDuration The default personal reference duration
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.setPersonPersonalReferenceDuration(
+suspend fun XesarConnect.setPersonPersonalReferenceDurationAsync(
     personalReferenceDuration: PersonalLog,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<PartitionChanged> {
-    return sendCommand<SetPersonPersonalReferenceDurationMapi, PartitionChanged>(
+): SingleEventResult<PartitionChanged> {
+    return sendCommandAsync<SetPersonPersonalReferenceDurationMapi, PartitionChanged>(
         Topics.Command.SET_PERSON_PERSONAL_REFERENCE_DURATION,
+        Topics.Event.PARTITION_CHANGED,
+        true,
         SetPersonPersonalReferenceDurationMapi(
             config.uuidGenerator.generateId(), personalReferenceDuration, token),
         requestConfig)
@@ -81,12 +89,14 @@ suspend fun XesarConnect.setPersonPersonalReferenceDuration(
  * @param replacementMediumDuration The replacement medium duration
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.setReplacementMediumDuration(
+suspend fun XesarConnect.setReplacementMediumDurationAsync(
     replacementMediumDuration: Short,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<PartitionChanged> {
-    return sendCommand<SetReplacementMediumDurationMapi, PartitionChanged>(
+): SingleEventResult<PartitionChanged> {
+    return sendCommandAsync<SetReplacementMediumDurationMapi, PartitionChanged>(
         Topics.Command.SET_REPLACEMENT_MEDIUM_DURATION,
+        Topics.Event.PARTITION_CHANGED,
+        true,
         SetReplacementMediumDurationMapi(
             config.uuidGenerator.generateId(), replacementMediumDuration, token),
         requestConfig)
@@ -97,12 +107,14 @@ suspend fun XesarConnect.setReplacementMediumDuration(
  * @param validityThreshold The validity threshold
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.setValidityThreshold(
+suspend fun XesarConnect.setValidityThresholdAsync(
     validityThreshold: Short,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<PartitionChanged> {
-    return sendCommand<SetValidityThresholdMapi, PartitionChanged>(
+): SingleEventResult<PartitionChanged> {
+    return sendCommandAsync<SetValidityThresholdMapi, PartitionChanged>(
         Topics.Command.SET_VALIDITY_THRESHOLD,
+        Topics.Event.PARTITION_CHANGED,
+        true,
         SetValidityThresholdMapi(config.uuidGenerator.generateId(), validityThreshold, token),
         requestConfig)
 }

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/extension/XesarConnectPersonExt.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/extension/XesarConnectPersonExt.kt
@@ -4,6 +4,7 @@ import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.messages.DisengagePeriod
 import com.open200.xesar.connect.messages.PersonalLog
+import com.open200.xesar.connect.messages.SingleEventResult
 import com.open200.xesar.connect.messages.command.*
 import com.open200.xesar.connect.messages.event.PersonChanged
 import com.open200.xesar.connect.messages.event.PersonCreated
@@ -50,15 +51,17 @@ suspend fun XesarConnect.queryPersonByIdAsync(
  * @param externalId The external ID of the person.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.changePersonInformation(
+suspend fun XesarConnect.changePersonInformationAsync(
     firstName: String? = null,
     lastName: String? = null,
     identifier: String? = null,
     externalId: String,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<PersonChanged> {
-    return sendCommand<ChangePersonInformationMapi, PersonChanged>(
+): SingleEventResult<PersonChanged> {
+    return sendCommandAsync<ChangePersonInformationMapi, PersonChanged>(
         Topics.Command.CHANGE_PERSON_INFORMATION,
+        Topics.Event.PERSON_CHANGED,
+        true,
         ChangePersonInformationMapi(
             config.uuidGenerator.generateId(), firstName, lastName, identifier, externalId, token),
         requestConfig)
@@ -73,16 +76,18 @@ suspend fun XesarConnect.changePersonInformation(
  * @param personId The ID of the person.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.createPerson(
+suspend fun XesarConnect.createPersonAsync(
     firstName: String,
     lastName: String,
     identifier: String? = null,
     externalId: String? = null,
     personId: UUID,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<PersonCreated> {
-    return sendCommand<CreatePersonMapi, PersonCreated>(
+): SingleEventResult<PersonCreated> {
+    return sendCommandAsync<CreatePersonMapi, PersonCreated>(
         Topics.Command.CREATE_PERSON,
+        Topics.Event.PERSON_CREATED,
+        true,
         CreatePersonMapi(
             config.uuidGenerator.generateId(),
             firstName,
@@ -99,12 +104,14 @@ suspend fun XesarConnect.createPerson(
  * @param externalId The external ID of the person.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.deletePerson(
+suspend fun XesarConnect.deletePersonAsync(
     externalId: String? = null,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<PersonDeleted> {
-    return sendCommand<DeletePersonMapi, PersonDeleted>(
+): SingleEventResult<PersonDeleted> {
+    return sendCommandAsync<DeletePersonMapi, PersonDeleted>(
         Topics.Command.DELETE_PERSON,
+        Topics.Event.PERSON_DELETED,
+        true,
         DeletePersonMapi(config.uuidGenerator.generateId(), externalId, token),
         requestConfig)
 }
@@ -117,13 +124,15 @@ suspend fun XesarConnect.deletePerson(
  *   remove authorization profile from person. Empty string gets ignored.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.setDefaultAuthorizationProfileForPerson(
+suspend fun XesarConnect.setDefaultAuthorizationProfileForPersonAsync(
     externalId: String,
     defaultAuthorizationProfileName: String? = null,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<PersonChanged> {
-    return sendCommand<SetDefaultAuthorizationProfileForPersonMapi, PersonChanged>(
+): SingleEventResult<PersonChanged> {
+    return sendCommandAsync<SetDefaultAuthorizationProfileForPersonMapi, PersonChanged>(
         Topics.Command.SET_DEFAULT_AUTHORIZATION_PROFILE_FOR_PERSON,
+        Topics.Event.PERSON_CHANGED,
+        true,
         SetDefaultAuthorizationProfileForPersonMapi(
             config.uuidGenerator.generateId(), externalId, defaultAuthorizationProfileName, token),
         requestConfig)
@@ -135,13 +144,15 @@ suspend fun XesarConnect.setDefaultAuthorizationProfileForPerson(
  * @param disengagePeriod The disengage period.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.setDefaultDisengagePeriodForPerson(
+suspend fun XesarConnect.setDefaultDisengagePeriodForPersonAsync(
     externalId: String,
     disengagePeriod: DisengagePeriod,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<PersonChanged> {
-    return sendCommand<SetDefaultDisengagePeriodForPersonMapi, PersonChanged>(
+): SingleEventResult<PersonChanged> {
+    return sendCommandAsync<SetDefaultDisengagePeriodForPersonMapi, PersonChanged>(
         Topics.Command.SET_DEFAULT_DISENGAGE_PERIOD_FOR_PERSON,
+        Topics.Event.PERSON_CHANGED,
+        true,
         SetDefaultDisengagePeriodForPersonMapi(
             config.uuidGenerator.generateId(), disengagePeriod, externalId, token),
         requestConfig)
@@ -153,13 +164,15 @@ suspend fun XesarConnect.setDefaultDisengagePeriodForPerson(
  * @param personalReferenceDuration The default personal reference duration
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.setPersonalReferenceDurationInPerson(
+suspend fun XesarConnect.setPersonalReferenceDurationInPersonAsync(
     externalId: String,
     personalReferenceDuration: PersonalLog,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<PersonChanged> {
-    return sendCommand<SetPersonalReferenceDurationInPersonMapi, PersonChanged>(
+): SingleEventResult<PersonChanged> {
+    return sendCommandAsync<SetPersonalReferenceDurationInPersonMapi, PersonChanged>(
         Topics.Command.SET_PERSONAL_REFERENCE_DURATION_IN_PERSON,
+        Topics.Event.PERSON_CHANGED,
+        true,
         SetPersonalReferenceDurationInPersonMapi(
             config.uuidGenerator.generateId(), personalReferenceDuration, externalId, token),
         requestConfig)

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/extension/XesarConnectTimeProfileExt.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/extension/XesarConnectTimeProfileExt.kt
@@ -4,6 +4,7 @@ import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.messages.ExceptionTimeSerie
 import com.open200.xesar.connect.messages.ExceptionTimepointSerie
+import com.open200.xesar.connect.messages.SingleEventResult
 import com.open200.xesar.connect.messages.TimePointSerie
 import com.open200.xesar.connect.messages.TimeSerie
 import com.open200.xesar.connect.messages.command.*
@@ -51,16 +52,18 @@ suspend fun XesarConnect.queryTimeProfileByIdAsync(
  * @param exceptionTimeSeries The exception time series of the time profile.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.changeAuthorizationTimeProfile(
+suspend fun XesarConnect.changeAuthorizationTimeProfileAsync(
     timeProfileId: UUID,
     timeProfileName: String,
     description: String? = null,
     timeSeries: List<TimeSerie> = emptyList(),
     exceptionTimeSeries: List<ExceptionTimeSerie> = emptyList(),
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<AuthorizationTimeProfileChanged> {
-    return sendCommand<ChangeAuthorizationTimeProfileMapi, AuthorizationTimeProfileChanged>(
+): SingleEventResult<AuthorizationTimeProfileChanged> {
+    return sendCommandAsync<ChangeAuthorizationTimeProfileMapi, AuthorizationTimeProfileChanged>(
         Topics.Command.CHANGE_AUTHORIZATION_TIME_PROFILE,
+        Topics.Event.AUTHORIZATION_TIME_PROFILE_CHANGED,
+        true,
         ChangeAuthorizationTimeProfileMapi(
             config.uuidGenerator.generateId(),
             timeProfileId,
@@ -84,7 +87,7 @@ suspend fun XesarConnect.changeAuthorizationTimeProfile(
  * @param timePointSeries The time point series of the time profile.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.changeOfficeModeTimeProfile(
+suspend fun XesarConnect.changeOfficeModeTimeProfileAsync(
     timeProfileId: UUID,
     name: String,
     description: String? = null,
@@ -93,9 +96,11 @@ suspend fun XesarConnect.changeOfficeModeTimeProfile(
     exceptionTimePointSeries: List<ExceptionTimeSerie>? = emptyList(),
     timePointSeries: List<TimePointSerie>? = emptyList(),
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<OfficeModeTimeProfileChanged> {
-    return sendCommand<ChangeOfficeModeTimeProfileMapi, OfficeModeTimeProfileChanged>(
+): SingleEventResult<OfficeModeTimeProfileChanged> {
+    return sendCommandAsync<ChangeOfficeModeTimeProfileMapi, OfficeModeTimeProfileChanged>(
         Topics.Command.CHANGE_OFFICE_MODE_TIME_PROFILE,
+        Topics.Event.OFFICE_MODE_TIME_PROFILE_CHANGED,
+        true,
         ChangeOfficeModeTimeProfileMapi(
             config.uuidGenerator.generateId(),
             timeProfileId,
@@ -120,7 +125,7 @@ suspend fun XesarConnect.changeOfficeModeTimeProfile(
  * @param timeProfileId The ID of the office mode time profile.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.createOfficeModeTimeProfile(
+suspend fun XesarConnect.createOfficeModeTimeProfileAsync(
     timeSeries: List<TimeSerie> = emptyList(),
     exceptionTimeSeries: List<ExceptionTimeSerie> = emptyList(),
     exceptionTimePointSeries: List<ExceptionTimepointSerie> = emptyList(),
@@ -129,9 +134,11 @@ suspend fun XesarConnect.createOfficeModeTimeProfile(
     timePointSeries: List<TimePointSerie> = emptyList(),
     timeProfileId: UUID,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<OfficeModeTimeProfileCreated> {
-    return sendCommand<CreateOfficeModeTimeProfileMapi, OfficeModeTimeProfileCreated>(
+): SingleEventResult<OfficeModeTimeProfileCreated> {
+    return sendCommandAsync<CreateOfficeModeTimeProfileMapi, OfficeModeTimeProfileCreated>(
         Topics.Command.CREATE_OFFICE_MODE_TIME_PROFILE,
+        Topics.Event.OFFICE_MODE_TIME_PROFILE_CREATED,
+        true,
         CreateOfficeModeTimeProfileMapi(
             config.uuidGenerator.generateId(),
             timeSeries,
@@ -151,12 +158,14 @@ suspend fun XesarConnect.createOfficeModeTimeProfile(
  * @param timeProfileId The ID of the office mode time profile to delete.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.deleteOfficeModeTimeProfile(
+suspend fun XesarConnect.deleteOfficeModeTimeProfileAsync(
     timeProfileId: UUID,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<OfficeModeTimeProfileDeleted> {
-    return sendCommand<DeleteOfficeModeTimeProfileMapi, OfficeModeTimeProfileDeleted>(
+): SingleEventResult<OfficeModeTimeProfileDeleted> {
+    return sendCommandAsync<DeleteOfficeModeTimeProfileMapi, OfficeModeTimeProfileDeleted>(
         Topics.Command.DELETE_OFFICE_MODE_TIME_PROFILE,
+        Topics.Event.OFFICE_MODE_TIME_PROFILE_DELETED,
+        true,
         DeleteOfficeModeTimeProfileMapi(config.uuidGenerator.generateId(), timeProfileId, token),
         requestConfig)
 }
@@ -171,16 +180,18 @@ suspend fun XesarConnect.deleteOfficeModeTimeProfile(
  * @param timeProfileId The ID of the authorization time profile.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.createAuthorizationTimeProfile(
+suspend fun XesarConnect.createAuthorizationTimeProfileAsync(
     timeSeries: List<TimeSerie> = emptyList(),
     exceptionTimeSeries: List<ExceptionTimeSerie> = emptyList(),
     name: String,
     description: String? = null,
     timeProfileId: UUID,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<AuthorizationTimeProfileCreated> {
-    return sendCommand<CreateAuthorizationTimeProfileMapi, AuthorizationTimeProfileCreated>(
+): SingleEventResult<AuthorizationTimeProfileCreated> {
+    return sendCommandAsync<CreateAuthorizationTimeProfileMapi, AuthorizationTimeProfileCreated>(
         Topics.Command.CREATE_AUTHORIZATION_TIME_PROFILE,
+        Topics.Event.AUTHORIZATION_TIME_PROFILE_CREATED,
+        true,
         CreateAuthorizationTimeProfileMapi(
             config.uuidGenerator.generateId(),
             timeSeries,
@@ -197,12 +208,14 @@ suspend fun XesarConnect.createAuthorizationTimeProfile(
  * @param timeProfileId The ID of the authorization time profile to delete.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.deleteAuthorizationTimeProfile(
+suspend fun XesarConnect.deleteAuthorizationTimeProfileAsync(
     timeProfileId: UUID,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<AuthorizationTimeProfileDeleted> {
-    return sendCommand<DeleteAuthorizationTimeProfileMapi, AuthorizationTimeProfileDeleted>(
+): SingleEventResult<AuthorizationTimeProfileDeleted> {
+    return sendCommandAsync<DeleteAuthorizationTimeProfileMapi, AuthorizationTimeProfileDeleted>(
         Topics.Command.DELETE_AUTHORIZATION_TIME_PROFILE,
+        Topics.Event.AUTHORIZATION_TIME_PROFILE_DELETED,
+        true,
         DeleteAuthorizationTimeProfileMapi(config.uuidGenerator.generateId(), timeProfileId, token),
         requestConfig)
 }

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/extension/XesarConnectUserGroupExt.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/extension/XesarConnectUserGroupExt.kt
@@ -2,10 +2,10 @@ package com.open200.xesar.connect.extension
 
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
+import com.open200.xesar.connect.messages.SingleEventResult
 import com.open200.xesar.connect.messages.command.ConfigureAssignableAuthorizationProfilesMapi
 import com.open200.xesar.connect.messages.event.UserGroupChanged
 import java.util.*
-import kotlinx.coroutines.Deferred
 
 /**
  * Configures the assignable authorization profiles for a user group asynchronously.
@@ -15,13 +15,15 @@ import kotlinx.coroutines.Deferred
  * @param requestConfig The request configuration (optional).
  * @return A deferred object that resolves to a response containing the user group changed event.
  */
-suspend fun XesarConnect.configureAssignableAuthorizationProfiles(
+suspend fun XesarConnect.configureAssignableAuthorizationProfilesAsync(
     assignableAuthorizationProfiles: List<UUID>,
     userGroupId: UUID,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<UserGroupChanged> {
-    return sendCommand<ConfigureAssignableAuthorizationProfilesMapi, UserGroupChanged>(
+): SingleEventResult<UserGroupChanged> {
+    return sendCommandAsync<ConfigureAssignableAuthorizationProfilesMapi, UserGroupChanged>(
         Topics.Command.CONFIGURE_ASSIGNABLE_AUTHORIZATION_PROFILES,
+        Topics.Event.USER_GROUP_CHANGED,
+        true,
         ConfigureAssignableAuthorizationProfilesMapi(
             config.uuidGenerator.generateId(), assignableAuthorizationProfiles, userGroupId, token),
         requestConfig)

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/extension/XesarConnectZoneExt.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/extension/XesarConnectZoneExt.kt
@@ -2,6 +2,7 @@ package com.open200.xesar.connect.extension
 
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
+import com.open200.xesar.connect.messages.SingleEventResult
 import com.open200.xesar.connect.messages.command.*
 import com.open200.xesar.connect.messages.event.InstallationPointsInZoneChanged
 import com.open200.xesar.connect.messages.event.ZoneChanged
@@ -9,10 +10,8 @@ import com.open200.xesar.connect.messages.event.ZoneCreated
 import com.open200.xesar.connect.messages.event.ZoneDeleted
 import com.open200.xesar.connect.messages.query.QueryList
 import com.open200.xesar.connect.messages.query.Zone
-import com.open200.xesar.connect.utils.UUIDSerializer
 import java.util.*
 import kotlinx.coroutines.Deferred
-import kotlinx.serialization.Serializable
 
 /**
  * Queries the list of zones asynchronously.
@@ -48,13 +47,15 @@ suspend fun XesarConnect.queryZoneByIdAsync(
  * @param zoneId The ID of the zone.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.addInstallationPointToZone(
+suspend fun XesarConnect.addInstallationPointToZoneAsync(
     installationPointId: UUID,
     zoneId: UUID,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<InstallationPointsInZoneChanged> {
-    return sendCommand<AddInstallationPointToZoneMapi, InstallationPointsInZoneChanged>(
+): SingleEventResult<InstallationPointsInZoneChanged> {
+    return sendCommandAsync<AddInstallationPointToZoneMapi, InstallationPointsInZoneChanged>(
         Topics.Command.ADD_INSTALLATION_POINT_TO_ZONE,
+        Topics.Event.INSTALLATION_POINTS_IN_ZONE_CHANGED,
+        true,
         AddInstallationPointToZoneMapi(
             config.uuidGenerator.generateId(), installationPointId, zoneId, token),
         requestConfig)
@@ -67,14 +68,16 @@ suspend fun XesarConnect.addInstallationPointToZone(
  * @param zoneId The ID of the zone.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.changeZoneData(
+suspend fun XesarConnect.changeZoneDataAsync(
     name: String,
     description: String,
     zoneId: UUID,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<ZoneChanged> {
-    return sendCommand<ChangeZoneDataMapi, ZoneChanged>(
+): SingleEventResult<ZoneChanged> {
+    return sendCommandAsync<ChangeZoneDataMapi, ZoneChanged>(
         Topics.Command.CHANGE_ZONE_DATA,
+        Topics.Event.ZONE_CHANGED,
+        true,
         ChangeZoneDataMapi(config.uuidGenerator.generateId(), name, description, zoneId, token),
         requestConfig)
 }
@@ -87,15 +90,17 @@ suspend fun XesarConnect.changeZoneData(
  * @param zoneId The ID of the zone.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.createZone(
-    installationPoints: List<@Serializable(with = UUIDSerializer::class) UUID> = emptyList(),
+suspend fun XesarConnect.createZoneAsync(
+    installationPoints: List<UUID> = emptyList(),
     name: String,
     description: String? = null,
     zoneId: UUID,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<ZoneCreated> {
-    return sendCommand<CreateZoneMapi, ZoneCreated>(
+): SingleEventResult<ZoneCreated> {
+    return sendCommandAsync<CreateZoneMapi, ZoneCreated>(
         Topics.Command.CREATE_ZONE,
+        Topics.Event.ZONE_CREATED,
+        true,
         CreateZoneMapi(
             config.uuidGenerator.generateId(),
             installationPoints,
@@ -111,12 +116,14 @@ suspend fun XesarConnect.createZone(
  * @param zoneId The ID of the zone.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.deleteZone(
+suspend fun XesarConnect.deleteZoneAsync(
     zoneId: UUID,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<ZoneDeleted> {
-    return sendCommand<DeleteZoneMapi, ZoneDeleted>(
+): SingleEventResult<ZoneDeleted> {
+    return sendCommandAsync<DeleteZoneMapi, ZoneDeleted>(
         Topics.Command.DELETE_ZONE,
+        Topics.Event.ZONE_DELETED,
+        true,
         DeleteZoneMapi(config.uuidGenerator.generateId(), zoneId, token),
         requestConfig)
 }
@@ -127,13 +134,15 @@ suspend fun XesarConnect.deleteZone(
  * @param zoneId The ID of the zone.
  * @param requestConfig The request configuration (optional).
  */
-suspend fun XesarConnect.removeInstallationPointFromZone(
+suspend fun XesarConnect.removeInstallationPointFromZoneAsync(
     installationPointId: UUID,
     zoneId: UUID,
     requestConfig: XesarConnect.RequestConfig = buildRequestConfig()
-): Deferred<InstallationPointsInZoneChanged> {
-    return sendCommand<RemoveInstallationPointFromZoneMapi, InstallationPointsInZoneChanged>(
+): SingleEventResult<InstallationPointsInZoneChanged> {
+    return sendCommandAsync<RemoveInstallationPointFromZoneMapi, InstallationPointsInZoneChanged>(
         Topics.Command.REMOVE_INSTALLATION_POINT_FROM_ZONE,
+        Topics.Event.INSTALLATION_POINTS_IN_ZONE_CHANGED,
+        true,
         RemoveInstallationPointFromZoneMapi(
             config.uuidGenerator.generateId(), installationPointId, zoneId, token),
         requestConfig)

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/filters/ApiErrorFilter.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/filters/ApiErrorFilter.kt
@@ -1,0 +1,14 @@
+package com.open200.xesar.connect.filters
+
+import java.util.*
+
+class ApiErrorFilter(correlationId: UUID, private val aTopic: String) : MessageFilter {
+
+    private val correlationIdRegex =
+        Regex(
+            "\"${UUIDJsonName.correlationId}\":\\s*\"${Regex.fromLiteral(correlationId.toString())}\"")
+
+    override fun filter(topic: String, message: String): Boolean {
+        return message.contains(correlationIdRegex) && aTopic == topic
+    }
+}

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/filters/CommandIdFilter.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/filters/CommandIdFilter.kt
@@ -11,7 +11,7 @@ import java.util.UUID
 class CommandIdFilter(commandId: UUID) : MessageFilter {
 
     private val commandIdRegex =
-        Regex("\"commandId\":\\s*\"${Regex.fromLiteral(commandId.toString())}\"")
+        Regex("\"${UUIDJsonName.commandId}\":\\s*\"${Regex.fromLiteral(commandId.toString())}\"")
 
     /**
      * Filters the given topic and message based on the command ID.

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/filters/EventAndCommandIdFilter.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/filters/EventAndCommandIdFilter.kt
@@ -1,0 +1,13 @@
+package com.open200.xesar.connect.filters
+
+import java.util.UUID
+
+class EventAndCommandIdFilter(commandId: UUID, private val aTopic: String) : MessageFilter {
+
+    private val commandIdRegex =
+        Regex("\"commandId\":\\s*\"${Regex.fromLiteral(commandId.toString())}\"")
+
+    override fun filter(topic: String, message: String): Boolean {
+        return message.contains(commandIdRegex) && aTopic == topic
+    }
+}

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/filters/QueryIdFilter.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/filters/QueryIdFilter.kt
@@ -9,7 +9,7 @@ import java.util.*
  */
 class QueryIdFilter(requestId: UUID) : MessageFilter {
     private val requestIdRegex =
-        Regex("\"requestId\":\\s*\"${Regex.fromLiteral(requestId.toString())}\"")
+        Regex("\"${UUIDJsonName.requestId}\":\\s*\"${Regex.fromLiteral(requestId.toString())}\"")
 
     /**
      * Filters the given topic and message based on the query ID.

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/filters/UUIDJsonName.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/filters/UUIDJsonName.kt
@@ -1,0 +1,7 @@
+package com.open200.xesar.connect.filters
+
+enum class UUIDJsonName {
+    correlationId,
+    commandId,
+    requestId
+}

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/AddEvvaComponentResult.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/AddEvvaComponentResult.kt
@@ -1,0 +1,16 @@
+package com.open200.xesar.connect.messages
+
+import com.open200.xesar.connect.messages.event.EvvaComponentAdded
+import com.open200.xesar.connect.messages.event.InstallationPointChanged
+import java.util.Optional
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.awaitAll
+
+/** Pair of events returning from [com.open200.xesar.connect.extension.addEvvaComponentAsync] */
+data class AddEvvaComponentResult(
+    val installationPointChangedDeferred: Deferred<InstallationPointChanged>,
+    val evvaComponentAddedDeferred: Deferred<EvvaComponentAdded>,
+    val apiErrorDeferred: Deferred<Optional<ApiError>>
+) {
+    suspend fun await() = awaitAll(installationPointChangedDeferred, evvaComponentAddedDeferred)
+}

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/AssignAuthorizationProfileToMediumResult.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/AssignAuthorizationProfileToMediumResult.kt
@@ -1,0 +1,19 @@
+package com.open200.xesar.connect.messages
+
+import com.open200.xesar.connect.messages.event.MediumAuthorizationProfileChanged
+import com.open200.xesar.connect.messages.event.MediumChanged
+import java.util.*
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.awaitAll
+
+/**
+ * Pair of events returning from
+ * [com.open200.xesar.connect.extension.assignAuthorizationProfileToMediumAsync]
+ */
+class AssignAuthorizationProfileToMediumResult(
+    val mediumChangedDeferred: Deferred<MediumChanged>,
+    val mediumAuthorizationProfileChangedDeferred: Deferred<MediumAuthorizationProfileChanged>,
+    val apiErrorDeferred: Deferred<Optional<ApiError>>
+) {
+    suspend fun await() = awaitAll(mediumChangedDeferred, mediumAuthorizationProfileChangedDeferred)
+}

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/ChangeAuthorizationProfileResult.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/ChangeAuthorizationProfileResult.kt
@@ -1,0 +1,23 @@
+package com.open200.xesar.connect.messages
+
+import com.open200.xesar.connect.messages.event.*
+import java.util.*
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.awaitAll
+
+/**
+ * Pair of events returning from
+ * [com.open200.xesar.connect.extension.changeAuthorizationProfileAsync]
+ */
+class ChangeAuthorizationProfileResult(
+    val authorizationProfileInfoChangedDeferred: Deferred<AuthorizationProfileInfoChanged>,
+    val authorizationProfileAccessChangedDeferred: Deferred<AuthorizationProfileAccessChanged>,
+    val authorizationProfileChangedDeferred: Deferred<AuthorizationProfileChanged>,
+    val apiErrorDeferred: Deferred<Optional<ApiError>>
+) {
+    suspend fun await() =
+        awaitAll(
+            authorizationProfileInfoChangedDeferred,
+            authorizationProfileAccessChangedDeferred,
+            authorizationProfileChangedDeferred)
+}

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/CreateInstallationPointResult.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/CreateInstallationPointResult.kt
@@ -1,0 +1,18 @@
+package com.open200.xesar.connect.messages
+
+import com.open200.xesar.connect.messages.event.EvvaComponentAdded
+import com.open200.xesar.connect.messages.event.InstallationPointCreated
+import java.util.*
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.awaitAll
+
+/**
+ * Pair of events returning from [com.open200.xesar.connect.extension.createInstallationPointAsync]
+ */
+class CreateInstallationPointResult(
+    val installationPointCreatedDeferred: Deferred<InstallationPointCreated>,
+    val evvaComponentAddedDeferred: Deferred<EvvaComponentAdded>,
+    val apiErrorDeferred: Deferred<Optional<ApiError>>
+) {
+    suspend fun await() = awaitAll(installationPointCreatedDeferred, evvaComponentAddedDeferred)
+}

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/RequestAddMediumToInstallationResult.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/RequestAddMediumToInstallationResult.kt
@@ -1,0 +1,20 @@
+package com.open200.xesar.connect.messages
+
+import com.open200.xesar.connect.messages.event.AddMediumToInstallationRequested
+import com.open200.xesar.connect.messages.event.MediumAddedToInstallation
+import java.util.*
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.awaitAll
+
+/**
+ * Pair of events returning from
+ * [com.open200.xesar.connect.extension.requestToAddMediumToInstallationAsync]
+ */
+class RequestAddMediumToInstallationResult(
+    val addMediumToInstallationRequestedDeferred: Deferred<AddMediumToInstallationRequested>,
+    val mediumAddedToInstallationDeferred: Deferred<MediumAddedToInstallation>,
+    val apiErrorDeferred: Deferred<Optional<ApiError>>
+) {
+    suspend fun await() =
+        awaitAll(addMediumToInstallationRequestedDeferred, mediumAddedToInstallationDeferred)
+}

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/SingleEventResult.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/SingleEventResult.kt
@@ -1,0 +1,20 @@
+package com.open200.xesar.connect.messages
+
+import com.open200.xesar.connect.messages.event.Event
+import java.util.*
+import kotlinx.coroutines.Deferred
+
+/**
+ * Result object of a command returning a single event. It includes a deferred object with an event
+ * and a deferred object with a possible API error.
+ *
+ * @param eventDeferred will be completed with the event if no error occurs.
+ * @param apiErrorDeferred will be completed with an empty Optional if no error occurs. Otherwise,
+ *   it will contain an [ApiError].
+ */
+class SingleEventResult<out E : Event>(
+    val eventDeferred: Deferred<E>,
+    val apiErrorDeferred: Deferred<Optional<ApiError>>
+) {
+    suspend fun await() = eventDeferred.await()
+}

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/AddEvvaComponentMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/AddEvvaComponentMapi.kt
@@ -15,8 +15,8 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class AddEvvaComponentMapi(
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     val type: ComponentType,
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
     val token: String
 ) : Command

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/AddInstallationPointAuthorizationToMediumMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/AddInstallationPointAuthorizationToMediumMapi.kt
@@ -14,7 +14,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class AddInstallationPointAuthorizationToMediumMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     val authorization: AuthorizationData,
     val token: String

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/AddInstallationPointToZoneMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/AddInstallationPointToZoneMapi.kt
@@ -14,7 +14,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class AddInstallationPointToZoneMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     @Serializable(with = UUIDSerializer::class) val installationPointId: UUID,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     val token: String

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/AddZoneAuthorizationToMediumMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/AddZoneAuthorizationToMediumMapi.kt
@@ -14,7 +14,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class AddZoneAuthorizationToMediumMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     val authorization: AuthorizationData,
     val token: String

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/AssignAuthorizationProfileToMediumMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/AssignAuthorizationProfileToMediumMapi.kt
@@ -14,8 +14,8 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class AssignAuthorizationProfileToMediumMapi(
-    @Serializable(with = UUIDSerializer::class) val authorizationProfileId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
+    @Serializable(with = UUIDSerializer::class) val authorizationProfileId: UUID? = null,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
     val token: String
 ) : Command

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/AssignPersonToMediumMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/AssignPersonToMediumMapi.kt
@@ -14,7 +14,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class AssignPersonToMediumMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     @Serializable(with = UUIDSerializer::class) val personId: UUID,
     val token: String

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/ChangeAuthorizationProfileMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/ChangeAuthorizationProfileMapi.kt
@@ -25,6 +25,6 @@ data class ChangeAuthorizationProfileMapi(
     @Serializable(with = UUIDSerializer::class) val standardTimeProfile: UUID? = null,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     val zones: List<Authorization>,
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     val token: String
 ) : Command

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/ChangeAuthorizationTimeProfileMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/ChangeAuthorizationTimeProfileMapi.kt
@@ -19,7 +19,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class ChangeAuthorizationTimeProfileMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     val name: String,
     val description: String? = null,

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/ChangeCalendarMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/ChangeCalendarMapi.kt
@@ -17,7 +17,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class ChangeCalendarMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     val name: String,
     val specialDays: List<@Serializable(with = LocalDateSerializer::class) LocalDate> = emptyList(),
     @Serializable(with = UUIDSerializer::class) val id: UUID,

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/ChangeCodingStationMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/ChangeCodingStationMapi.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class ChangeCodingStationMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     val name: String? = null,
     val description: String? = null,

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/ChangeInstallationPointMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/ChangeInstallationPointMapi.kt
@@ -17,7 +17,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class ChangeInstallationPointMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     @Serializable(with = UUIDSerializer::class) val aggregateId: UUID,
     val installationType: String? = null,
     val name: String? = null,

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/ChangeOfficeModeTimeProfileMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/ChangeOfficeModeTimeProfileMapi.kt
@@ -24,7 +24,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class ChangeOfficeModeTimeProfileMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     val name: String,
     val description: String? = null,

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/ChangePersonInformationMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/ChangePersonInformationMapi.kt
@@ -16,7 +16,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class ChangePersonInformationMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     val firstName: String? = null,
     val lastName: String? = null,
     val identifier: String? = null,

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/ChangeZoneDataMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/ChangeZoneDataMapi.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class ChangeZoneDataMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     val name: String,
     val description: String,
     @Serializable(with = UUIDSerializer::class) val id: UUID,

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/Command.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/Command.kt
@@ -1,12 +1,18 @@
 package com.open200.xesar.connect.messages.command
 
 import com.open200.xesar.connect.messages.Message
+import com.open200.xesar.connect.utils.UUIDSerializer
+import java.util.*
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 /** Represents a command message in the system. */
-@Serializable sealed interface Command : Message
+@Serializable
+sealed interface Command : Message {
+    /** The id of the command. */
+    @Serializable(with = UUIDSerializer::class) val commandId: UUID
+}
 
 /**
  * Encodes a message of type [T] to its JSON representation.

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/ConfigureAssignableAuthorizationProfilesMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/ConfigureAssignableAuthorizationProfilesMapi.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class ConfigureAssignableAuthorizationProfilesMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     val assignableAuthorizationProfiles: List<@Serializable(with = UUIDSerializer::class) UUID>,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     val token: String

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/ConfigureManualOfficeModeAndShopModeMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/ConfigureManualOfficeModeAndShopModeMapi.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class ConfigureManualOfficeModeAndShopModeMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     val shopMode: Boolean? = null,
     val manualOfficeMode: Boolean? = null,
     @Serializable(with = UUIDSerializer::class) val id: UUID? = null,

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/ConfigureMediaUpgradeMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/ConfigureMediaUpgradeMapi.kt
@@ -14,7 +14,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class ConfigureMediaUpgradeMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     val upgradeMedia: Boolean? = null,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     val token: String

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/ConfigureOfficeModeTimeProfileMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/ConfigureOfficeModeTimeProfileMapi.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class ConfigureOfficeModeTimeProfileMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     @Serializable(with = UUIDSerializer::class) val timeProfileId: UUID? = null,
     val token: String

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/ConfigureReleaseDurationMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/ConfigureReleaseDurationMapi.kt
@@ -17,7 +17,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class ConfigureReleaseDurationMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     val releaseDurationShort: Int? = null,
     val releaseDurationLong: Int? = null,
     @Serializable(with = UUIDSerializer::class) val id: UUID,

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/CreateAuthorizationProfileMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/CreateAuthorizationProfileMapi.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class CreateAuthorizationProfileMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     val name: String,
     val description: String? = null,
     @Serializable(with = UUIDSerializer::class) val id: UUID,

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/CreateAuthorizationTimeProfileMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/CreateAuthorizationTimeProfileMapi.kt
@@ -19,7 +19,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class CreateAuthorizationTimeProfileMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     val timeSeries: List<TimeSerie> = emptyList(),
     val exceptionTimeSeries: List<ExceptionTimeSerie> = emptyList(),
     val name: String,

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/CreateCalendarMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/CreateCalendarMapi.kt
@@ -17,7 +17,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class CreateCalendarMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     val name: String,
     val specialDays: List<@Serializable(with = LocalDateSerializer::class) LocalDate> = emptyList(),
     @Serializable(with = UUIDSerializer::class) val id: UUID,

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/CreateCodingStationMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/CreateCodingStationMapi.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class CreateCodingStationMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     val name: String,
     val description: String? = null,
     @Serializable(with = UUIDSerializer::class) val id: UUID,

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/CreateInstallationPointMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/CreateInstallationPointMapi.kt
@@ -15,7 +15,6 @@ import kotlinx.serialization.Serializable
  *   properties as values. Use this if the installation point has more than one evva component. For
  *   example the Evva component type 'WallReader2x'.
  * @param commandId The id of the command.
- * @param properties The properties of the installation point.
  * @param token The token of the command.
  */
 @Serializable
@@ -25,8 +24,7 @@ data class CreateInstallationPointMapi(
     val linkedInstallationPoints:
         Map<@Serializable(with = UUIDSerializer::class) UUID, Properties> =
         emptyMap(),
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
-    val properties: Properties,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     val token: Token
 ) : Command {
     @Serializable

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/CreateOfficeModeTimeProfileMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/CreateOfficeModeTimeProfileMapi.kt
@@ -25,7 +25,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class CreateOfficeModeTimeProfileMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     val timeSeries: List<TimeSerie> = emptyList(),
     val exceptionTimeSeries: List<ExceptionTimeSerie> = emptyList(),
     val exceptionTimePointSeries: List<ExceptionTimepointSerie> = emptyList(),

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/CreatePersonMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/CreatePersonMapi.kt
@@ -17,7 +17,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class CreatePersonMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     val firstName: String,
     val lastName: String,
     val identifier: String? = null,

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/CreateZoneMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/CreateZoneMapi.kt
@@ -16,7 +16,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class CreateZoneMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     val installationPoints: List<@Serializable(with = UUIDSerializer::class) UUID> = emptyList(),
     val name: String,
     val description: String? = null,

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/DeleteAuthorizationProfileMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/DeleteAuthorizationProfileMapi.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class DeleteAuthorizationProfileMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     val token: String
 ) : Command

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/DeleteAuthorizationTimeProfileMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/DeleteAuthorizationTimeProfileMapi.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class DeleteAuthorizationTimeProfileMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     val token: String
 ) : Command

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/DeleteCalendarMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/DeleteCalendarMapi.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class DeleteCalendarMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     val token: String
 ) : Command

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/DeleteCodingStationMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/DeleteCodingStationMapi.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class DeleteCodingStationMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     val token: String
 ) : Command

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/DeleteInstallationPointMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/DeleteInstallationPointMapi.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class DeleteInstallationPointMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     val token: String
 ) : Command

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/DeleteOfficeModeTimeProfileMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/DeleteOfficeModeTimeProfileMapi.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class DeleteOfficeModeTimeProfileMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     val token: String
 ) : Command

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/DeletePersonMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/DeletePersonMapi.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class DeletePersonMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     val externalId: String? = null,
     val token: String
 ) : Command

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/DeleteZoneMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/DeleteZoneMapi.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class DeleteZoneMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     val token: String
 ) : Command

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/FindComponent.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/FindComponent.kt
@@ -14,7 +14,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class FindComponent(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     @Serializable(with = UUIDSerializer::class) val installationPointId: UUID,
     val enable: Boolean? = null,
     val token: String

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/ForceRemoveEvvaComponentMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/ForceRemoveEvvaComponentMapi.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class ForceRemoveEvvaComponentMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     val token: String
 ) : Command

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/LockMediumMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/LockMediumMapi.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class LockMediumMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     val token: String
 ) : Command

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/Login.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/Login.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class Login(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     val username: String,
     val password: String
 ) : Command

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/Logout.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/Logout.kt
@@ -1,5 +1,6 @@
 package com.open200.xesar.connect.messages.command
 
+import com.open200.xesar.connect.messages.Message
 import kotlinx.serialization.Serializable
 
 /**
@@ -7,4 +8,4 @@ import kotlinx.serialization.Serializable
  *
  * @param token The token associated with the user's session to be logged out.
  */
-@Serializable data class Logout(val token: String) : Command
+@Serializable data class Logout(val token: String) : Message

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/PrepareRemovalOfEvvaComponentMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/PrepareRemovalOfEvvaComponentMapi.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class PrepareRemovalOfEvvaComponentMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     val token: String
 ) : Command

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/Query.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/Query.kt
@@ -1,5 +1,6 @@
 package com.open200.xesar.connect.messages.command
 
+import com.open200.xesar.connect.messages.Message
 import com.open200.xesar.connect.utils.FilterTypeSerializer
 import com.open200.xesar.connect.utils.UUIDSerializer
 import java.util.UUID
@@ -21,7 +22,7 @@ class Query(
     val token: String,
     @Serializable(with = UUIDSerializer::class) val id: UUID?,
     val params: Params? = null
-) : Command {
+) : Message {
 
     /**
      * Represents the parameters for a query.

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/RemoteDisengage.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/RemoteDisengage.kt
@@ -14,7 +14,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class RemoteDisengage(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     @Serializable(with = UUIDSerializer::class) val installationPointId: UUID,
     val extended: Boolean? = null,
     val token: String

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/RemoteDisengagePermanent.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/RemoteDisengagePermanent.kt
@@ -14,7 +14,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class RemoteDisengagePermanent(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     @Serializable(with = UUIDSerializer::class) val installationPointId: UUID,
     val enable: Boolean? = null,
     val token: String

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/RemoveInstallationPointAuthorizationFromMediumMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/RemoveInstallationPointAuthorizationFromMediumMapi.kt
@@ -14,7 +14,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class RemoveInstallationPointAuthorizationFromMediumMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     @Serializable(with = UUIDSerializer::class) val authorization: UUID? = null,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     val token: String

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/RemoveInstallationPointFromZoneMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/RemoveInstallationPointFromZoneMapi.kt
@@ -14,7 +14,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class RemoveInstallationPointFromZoneMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     @Serializable(with = UUIDSerializer::class) val installationPointId: UUID,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     val token: String

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/RemoveZoneAuthorizationFromMediumMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/RemoveZoneAuthorizationFromMediumMapi.kt
@@ -14,7 +14,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class RemoveZoneAuthorizationFromMediumMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     @Serializable(with = UUIDSerializer::class) val authorization: UUID? = null,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     val token: String

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/RequestAddMediumToInstallationMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/RequestAddMediumToInstallationMapi.kt
@@ -20,6 +20,6 @@ data class RequestAddMediumToInstallationMapi(
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     @Serializable(with = UUIDSerializer::class) val terminalId: UUID,
     val label: String? = null,
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     val token: String
 ) : Command

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/RevertPrepareRemovalOfEvvaComponentMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/RevertPrepareRemovalOfEvvaComponentMapi.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class RevertPrepareRemovalOfEvvaComponentMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     val token: String,
 ) : Command

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/SetAccessBeginAtMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/SetAccessBeginAtMapi.kt
@@ -16,7 +16,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class SetAccessBeginAtMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     @Serializable(with = LocalDateTimeSerializer::class) val accessBeginAt: LocalDateTime? = null,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     val token: String,

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/SetAccessEndAtMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/SetAccessEndAtMapi.kt
@@ -16,7 +16,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class SetAccessEndAtMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     @Serializable(with = LocalDateTimeSerializer::class) val accessEndAt: LocalDateTime? = null,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     val token: String,

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/SetDailySchedulerExecutionTimeMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/SetDailySchedulerExecutionTimeMapi.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class SetDailySchedulerExecutionTimeMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     @Serializable(with = LocalTimeSerializer::class) val dailySchedulerExecutionTime: LocalTime,
     val token: String
 ) : Command

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/SetDefaultAuthorizationProfileForPersonMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/SetDefaultAuthorizationProfileForPersonMapi.kt
@@ -16,7 +16,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class SetDefaultAuthorizationProfileForPersonMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     val externalId: String,
     val defaultAuthorizationProfileName: String? = null,
     val token: String,

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/SetDefaultDisengagePeriodForPersonMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/SetDefaultDisengagePeriodForPersonMapi.kt
@@ -17,7 +17,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class SetDefaultDisengagePeriodForPersonMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     val disengagePeriod: DisengagePeriod,
     val externalId: String,
     val token: String

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/SetDefaultValidityDurationMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/SetDefaultValidityDurationMapi.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class SetDefaultValidityDurationMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     val validityDuration: Short,
     val token: String
 ) : Command

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/SetDisengagePeriodOnMediumMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/SetDisengagePeriodOnMediumMapi.kt
@@ -17,7 +17,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class SetDisengagePeriodOnMediumMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     val disengagePeriod: DisengagePeriod,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     val token: String

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/SetInstallationPointPersonalReferenceDurationMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/SetInstallationPointPersonalReferenceDurationMapi.kt
@@ -14,7 +14,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class SetInstallationPointPersonalReferenceDurationMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     val personalReferenceDuration: PersonalLog,
     val token: String
 ) : Command

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/SetLabelOnMediumMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/SetLabelOnMediumMapi.kt
@@ -14,7 +14,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class SetLabelOnMediumMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     val label: String,
     val token: String,

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/SetPersonPersonalReferenceDurationMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/SetPersonPersonalReferenceDurationMapi.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class SetPersonPersonalReferenceDurationMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     val personalReferenceDuration: PersonalLog,
     val token: String
 ) : Command

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/SetPersonalReferenceDurationForInstallationPointMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/SetPersonalReferenceDurationForInstallationPointMapi.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class SetPersonalReferenceDurationForInstallationPointMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     val personalReferenceDuration: PersonalLog,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     val token: String

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/SetPersonalReferenceDurationInPersonMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/SetPersonalReferenceDurationInPersonMapi.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class SetPersonalReferenceDurationInPersonMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     val newValue: PersonalLog,
     val externalId: String,
     val token: String

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/SetReplacementMediumDurationMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/SetReplacementMediumDurationMapi.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class SetReplacementMediumDurationMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     val replacementMediumDuration: Short,
     val token: String
 ) : Command

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/SetValidityDurationMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/SetValidityDurationMapi.kt
@@ -14,7 +14,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class SetValidityDurationMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     val validityDuration: Short? = null,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     val token: String

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/SetValidityThresholdMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/SetValidityThresholdMapi.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class SetValidityThresholdMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     val validityThreshold: Short,
     val token: String
 ) : Command

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/WithdrawAuthorizationProfileFromMediumMapi.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/command/WithdrawAuthorizationProfileFromMediumMapi.kt
@@ -17,7 +17,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class WithdrawAuthorizationProfileFromMediumMapi(
-    @Serializable(with = UUIDSerializer::class) val commandId: UUID,
+    override val commandId: @Serializable(with = UUIDSerializer::class) UUID,
     @Serializable(with = UUIDSerializer::class) val authorizationProfileId: UUID? = null,
     @Serializable(with = UUIDSerializer::class) val id: UUID,
     val token: String

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/event/AddMediumToInstallationRequested.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/event/AddMediumToInstallationRequested.kt
@@ -14,11 +14,12 @@ import kotlinx.serialization.Serializable
  * @param terminalId The id of the terminal.
  * @param label The label of the medium.
  */
+@Serializable
 data class AddMediumToInstallationRequested(
-    @Serializable(with = UUIDSerializer::class) val aggregateId: UUID,
-    @Serializable(with = UUIDSerializer::class) val partitionId: UUID,
-    val hardwareId: String,
-    val mediumIdentifier: Long,
-    @Serializable(with = UUIDSerializer::class) val terminalId: UUID,
+    @Serializable(with = UUIDSerializer::class) val aggregateId: UUID? = null,
+    @Serializable(with = UUIDSerializer::class) val partitionId: UUID? = null,
+    val hardwareId: String? = null,
+    val mediumIdentifier: Long? = null,
+    @Serializable(with = UUIDSerializer::class) val terminalId: UUID? = null,
     val label: String? = null,
 ) : Event

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/event/AuthorizationProfileAccessChanged.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/event/AuthorizationProfileAccessChanged.kt
@@ -1,0 +1,44 @@
+package com.open200.xesar.connect.messages.event
+
+import com.open200.xesar.connect.messages.command.Authorization
+import com.open200.xesar.connect.utils.UUIDSerializer
+import java.util.*
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents an event POJO as a response of a command when the data of an authorization profile has
+ * changed.
+ *
+ * @param id The id of the authorization profile.
+ * @param manualOfficeMode The manual office mode.
+ * @param standardTimeProfile The used standard time profile id or null for an all-day time profile.
+ * @param oldStandardTimeProfile The previous standard time profile id or null for an all-day time
+ *   profile.
+ * @param individual The individual.
+ * @param addedInstallationPoints The added installation points.
+ * @param removedInstallationPoints The removed installation points.
+ * @param addedZones The added zones.
+ * @param removedZones The removed zones.
+ * @param installationPoints The installation points.
+ * @param zones The zones.
+ * @param addedTimeProfiles The added time profiles.
+ * @param removedTimeProfiles The removed time profiles.
+ * @param media The media.
+ */
+@Serializable
+data class AuthorizationProfileAccessChanged(
+    var id: @Serializable(with = UUIDSerializer::class) UUID? = null,
+    var manualOfficeMode: Boolean? = null,
+    var standardTimeProfile: @Serializable(with = UUIDSerializer::class) UUID? = null,
+    var oldStandardTimeProfile: @Serializable(with = UUIDSerializer::class) UUID? = null,
+    var individual: Boolean? = null,
+    var addedInstallationPoints: List<Authorization> = emptyList(),
+    var removedInstallationPoints: List<Authorization> = emptyList(),
+    var addedZones: List<Authorization> = emptyList(),
+    var removedZones: List<Authorization> = emptyList(),
+    var installationPoints: List<Authorization> = emptyList(),
+    var zones: List<Authorization> = emptyList(),
+    var addedTimeProfiles: List<@Serializable(with = UUIDSerializer::class) UUID> = emptyList(),
+    var removedTimeProfiles: List<@Serializable(with = UUIDSerializer::class) UUID> = emptyList(),
+    var media: List<@Serializable(with = UUIDSerializer::class) UUID> = emptyList()
+) : Event

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/event/AuthorizationProfileChanged.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/event/AuthorizationProfileChanged.kt
@@ -1,0 +1,16 @@
+package com.open200.xesar.connect.messages.event
+
+import com.open200.xesar.connect.utils.UUIDSerializer
+import java.util.*
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents an event POJO as a response of a command when the data of an authorization profile has
+ * changed.
+ *
+ * @param id The id of the authorization profile.
+ */
+@Serializable
+data class AuthorizationProfileChanged(
+    val id: @Serializable(with = UUIDSerializer::class) UUID? = null
+) : Event

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/event/AuthorizationProfileInfoChanged.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/event/AuthorizationProfileInfoChanged.kt
@@ -1,0 +1,20 @@
+package com.open200.xesar.connect.messages.event
+
+import com.open200.xesar.connect.utils.UUIDSerializer
+import java.util.*
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents an event POJO as a response of a command to change the information of an authorization
+ * profile.
+ *
+ * @param name The name of the authorization profile.
+ * @param description The description of the authorization profile.
+ * @param id The id of the authorization profile.
+ */
+@Serializable
+data class AuthorizationProfileInfoChanged(
+    val name: String? = null,
+    val description: String? = null,
+    val id: @Serializable(with = UUIDSerializer::class) UUID? = null
+) : Event

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/event/EvvaComponentAdded.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/event/EvvaComponentAdded.kt
@@ -1,0 +1,75 @@
+package com.open200.xesar.connect.messages.event
+
+import com.open200.xesar.connect.messages.ComponentType
+import com.open200.xesar.connect.messages.query.BatteryCondition
+import com.open200.xesar.connect.messages.query.ComponentStatus
+import com.open200.xesar.connect.messages.query.OnlineStatus
+import com.open200.xesar.connect.utils.LocalDateTimeSerializer
+import com.open200.xesar.connect.utils.UUIDSerializer
+import java.time.LocalDateTime
+import java.util.*
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents an event POJO as a response of a command to add an EVVA component.
+ *
+ * @param id The id of the event.
+ * @param evvaComponentId The id of the EVVA component.
+ * @param type The type of the EVVA component.
+ * @param useOddKey Whether the EVVA component uses an odd key.
+ * @param nonce The nonce of the EVVA component.
+ * @param stateChangedAt The date and time when the state of the EVVA component was changed.
+ * @param batteryWarning Whether the battery of the EVVA component is low.
+ * @param batteryCondition The condition of the battery of the EVVA component.
+ * @param status The status of the EVVA component.
+ * @param onlineStatus The online status of the EVVA component.
+ * @param firmwareVersion The firmware version of the EVVA component.
+ * @param componentParts The parts of the EVVA component.
+ * @param serialNumber The serial number of the EVVA component.
+ */
+@Serializable
+data class EvvaComponentAdded(
+    val id: @Serializable(with = UUIDSerializer::class) UUID,
+    val evvaComponentId: @Serializable(with = UUIDSerializer::class) UUID,
+    val type: ComponentType? = null,
+    val useOddKey: Boolean? = null,
+    val nonce: Long? = null,
+    val stateChangedAt: @Serializable(with = LocalDateTimeSerializer::class) LocalDateTime,
+    val batteryWarning: Boolean? = null,
+    val batteryCondition: BatteryCondition? = null,
+    val status: ComponentStatus,
+    val onlineStatus: OnlineStatus? = null,
+    val firmwareVersion: FirmwareVersion? = null,
+    val componentParts: List<ComponentPart>? = emptyList(),
+    val serialNumber: String? = null
+) : Event {
+
+    @Serializable
+    data class FirmwareVersion(
+        val firmwareVariant: String? = null,
+        val major: Int? = null,
+        val minor: Int? = null,
+        val majorBootloader: Int? = null,
+        val mechanicalVersion: String? = null,
+        val internalRevision: String? = null,
+        val electricalVersion: String? = null,
+        val minorBootloader: Int? = null,
+        val firmwareUpdateFileFormatVersion: Int? = null,
+    )
+
+    @Serializable
+    data class ComponentPart(
+        val serialNumber: String? = null,
+        val hardwareVersion: HardwareVersion? = null,
+        val firmwareVersion: FirmwareVersion? = null,
+        val busAddress: String? = null,
+    )
+
+    @Serializable
+    data class HardwareVersion(
+        var hardwareComponentType: String? = null,
+        var versionHardware: Char? = null,
+        var productComponentType: String? = null,
+        var subComponent: Char? = null,
+    )
+}

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/event/InstallationPointCreated.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/event/InstallationPointCreated.kt
@@ -1,0 +1,103 @@
+package com.open200.xesar.connect.messages.event
+
+import com.open200.xesar.connect.messages.*
+import com.open200.xesar.connect.utils.LocalDateSerializer
+import com.open200.xesar.connect.utils.UUIDSerializer
+import java.time.LocalDate
+import java.util.*
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents an event POJO as a response of a command to create an installation point.
+ *
+ * @param componentType The type of the component.
+ * @param releaseDurationShort The short release duration of the installation point.
+ * @param instance The instance of the installation point.
+ * @param upgradeMedia The upgrade media flag of the installation point.
+ * @param partitionId The partition id of the installation point.
+ * @param personalReferenceDuration The personal reference duration of the installation point.
+ * @param timeProfileName The name of the time profile of the installation point.
+ * @param description The description of the installation point.
+ * @param nextDstTransition The next DST transition of the installation point.
+ * @param linkedInstallationPoints The list of linked installation points of the installation point.
+ * @param timeProfileId The id of the time profile of the installation point.
+ * @param accessId The access id of the installation point.
+ * @param shopMode The shop mode flag of the installation point.
+ * @param releaseDurationLong The long release duration of the installation point.
+ * @param installationType The type of the installation point.
+ * @param manualOfficeMode The manual office mode flag of the installation point.
+ * @param name The name of the installation point.
+ * @param afterNextDstTransition The after next DST transition of the installation point.
+ * @param evvaComponentId The id of the EVVA component of the installation point.
+ * @param id The id of the installation point.
+ * @param installationId The installation id of the installation point.
+ * @param timeProfileData The time profile data of the installation point.
+ * @param calendarData The calendar data of the installation point.
+ * @param openDoor The open door flag of the installation point.
+ */
+@Serializable
+data class InstallationPointCreated(
+    val componentType: ComponentType? = null,
+    val releaseDurationShort: Int? = null,
+    val instance: Int? = null,
+    val upgradeMedia: Boolean? = null,
+    val partitionId: String? = null,
+    val personalReferenceDuration: PersonalLog? = null,
+    val timeProfileName: String? = null,
+    val description: String? = null,
+    val nextDstTransition: String? = null,
+    val linkedInstallationPoints: List<LinkedInstallationPoint>? = emptyList(),
+    val timeProfileId: @Serializable(with = UUIDSerializer::class) UUID? = null,
+    val accessId: Long? = null,
+    val shopMode: Boolean? = null,
+    val releaseDurationLong: Int? = null,
+    val installationType: String? = null,
+    val manualOfficeMode: Boolean? = null,
+    val name: String? = null,
+    val afterNextDstTransition: String? = null,
+    val evvaComponentId: @Serializable(with = UUIDSerializer::class) UUID? = null,
+    val id: @Serializable(with = UUIDSerializer::class) UUID? = null,
+    val installationId: String? = null,
+    val timeProfileData: TimeProfileData? = null,
+    val calendarData: CalendarData? = null,
+    val openDoor: Boolean? = null
+) : Event {
+
+    @Serializable
+    data class TimeProfileData(
+        var timeSeries: List<TimeSerie>? = null,
+        var exceptionTimeSeries: List<ExceptionTimeSerie>? = emptyList(),
+        var timePointSeries: List<TimePointSerie>? = emptyList(),
+        var exceptionTimePointSeries: List<ExceptionTimepointSerie>? = emptyList()
+    )
+    @Serializable
+    data class LinkedInstallationPoint(
+        val aggregateId: @Serializable(with = UUIDSerializer::class) UUID? = null,
+        val accessId: Long? = null,
+        val installationPointProperties: InstallationPointProperties? = null,
+        val evvaComponentId: @Serializable(with = UUIDSerializer::class) UUID? = null,
+        val componentType: ComponentType? = null
+    ) {
+        @Serializable
+        data class InstallationPointProperties(
+            var name: String,
+            var description: String? = null,
+            var partitionId: @Serializable(with = UUIDSerializer::class) UUID,
+            var releaseDurationShort: Int? = null,
+            var releaseDurationLong: Int? = null,
+            var installationId: String,
+            var installationType: String? = null,
+            var personalReferenceDuration: PersonalLog,
+            var timeProfileId: @Serializable(with = UUIDSerializer::class) UUID? = null,
+            var manualOfficeMode: Boolean? = null,
+            var shopMode: Boolean? = null,
+            var openDoor: Boolean? = null,
+            var upgradeMedia: Boolean? = null,
+        )
+    }
+    @Serializable
+    data class CalendarData(
+        var calendars: Map<Int, List<@Serializable(with = LocalDateSerializer::class) LocalDate>>? =
+            null
+    )
+}

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/event/MediumAddedToInstallation.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/event/MediumAddedToInstallation.kt
@@ -1,0 +1,23 @@
+package com.open200.xesar.connect.messages.event
+
+import com.open200.xesar.connect.utils.UUIDSerializer
+import java.util.*
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents an event POJO as a response of a command to add a medium to an installation.
+ *
+ * @param aggregateId The id of the installation.
+ * @param hardwareId The hardware ID of the installation.
+ * @param nativeId The native ID of the installation.
+ * @param mediumIdentifier The identifier of the medium.
+ * @param label The label of the medium.
+ */
+@Serializable
+data class MediumAddedToInstallation(
+    var aggregateId: @Serializable(with = UUIDSerializer::class) UUID? = null,
+    var hardwareId: String? = null,
+    var nativeId: String? = null,
+    var mediumIdentifier: Long? = null,
+    var label: String? = null
+) : Event

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/event/MediumAuthorizationProfileChanged.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/event/MediumAuthorizationProfileChanged.kt
@@ -1,0 +1,22 @@
+package com.open200.xesar.connect.messages.event
+
+import com.open200.xesar.connect.utils.UUIDSerializer
+import java.util.*
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents an event POJO as a response of a command to assign an individual authorization to a
+ * medium.
+ *
+ * @param id The id of the medium.
+ * @param newAuthorizationProfileId The id of the authorization profile that was added to the
+ *   medium.
+ * @param oldAuthorizationProfileId The id of the authorization profile that was removed from the
+ *   medium.
+ */
+@Serializable
+data class MediumAuthorizationProfileChanged(
+    var id: @Serializable(with = UUIDSerializer::class) UUID,
+    var newAuthorizationProfileId: @Serializable(with = UUIDSerializer::class) UUID? = null,
+    var oldAuthorizationProfileId: @Serializable(with = UUIDSerializer::class) UUID? = null
+) : Event

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/query/InstallationPoint.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/query/InstallationPoint.kt
@@ -41,7 +41,7 @@ data class InstallationPoint(
     val linkedInstallationPoints: List<@Serializable(with = UUIDSerializer::class) UUID>? =
         emptyList(),
     val onlineStatus: OnlineStatus? = null,
-    val componentType: ComponentType,
+    val componentType: ComponentType? = null,
     val releaseDurationShort: Int,
     val releaseDurationLong: Int,
     val logMode: String? = null,

--- a/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/query/TimeProfile.kt
+++ b/xesar-connect/src/main/kotlin/com/open200/xesar/connect/messages/query/TimeProfile.kt
@@ -12,10 +12,10 @@ data class TimeProfile(
     val timeSeries: List<TimeSerie>,
     val exceptionTimeSeries: List<ExceptionTimeSerie>,
     val exceptionTimePointSeries: List<ExceptionTimepointSerie>? = emptyList(),
-    val name: String,
+    val name: String? = null,
     val description: String? = null,
     val timePointSeries: List<TimePointSerie>? = emptyList(),
-    @Serializable(with = UUIDSerializer::class) val id: UUID,
+    @Serializable(with = UUIDSerializer::class) val id: UUID? = null,
     val type: TimeProfileType? = null,
     val validStandardTimeProfile: Boolean? = null
 ) : QueryListResource, QueryElementResource {

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/ConnectAndLoginTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/ConnectAndLoginTest.kt
@@ -97,7 +97,7 @@ class ConnectAndLoginTest :
                         XesarMqttClient.connectAsync(config).await().use { client ->
                             client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
 
-                            client.onMessage = { topic, payload ->
+                            client.onMessage = { _, payload ->
                                 loginReceived.complete(payload.decodeToString())
                             }
 

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/AddEvvaComponentTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/AddEvvaComponentTest.kt
@@ -1,0 +1,527 @@
+import com.open200.xesar.connect.Topics
+import com.open200.xesar.connect.XesarConnect
+import com.open200.xesar.connect.XesarMqttClient
+import com.open200.xesar.connect.exception.OptionalEventException
+import com.open200.xesar.connect.exception.ParsingException
+import com.open200.xesar.connect.exception.RequiredEventException
+import com.open200.xesar.connect.extension.addEvvaComponentAsync
+import com.open200.xesar.connect.messages.ApiError
+import com.open200.xesar.connect.messages.ComponentType
+import com.open200.xesar.connect.messages.encodeError
+import com.open200.xesar.connect.messages.event.*
+import com.open200.xesar.connect.messages.query.ComponentStatus
+import com.open200.xesar.connect.testutils.MosquittoContainer
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.common.runBlocking
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.extensions.testcontainers.perProject
+import io.kotest.matchers.equals.shouldBeEqual
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import java.time.LocalDateTime
+import java.util.*
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.launch
+
+class AddEvvaComponentTest :
+    FunSpec({
+        val container = MosquittoContainer.container()
+        val config = MosquittoContainer.config(container)
+        listener(container.perProject())
+        test("add evva component returning no event") {
+            coEvery { config.uuidGenerator.generateId() }
+                .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+            runBlocking {
+                val simulatedBackendReady = CompletableDeferred<Unit>()
+                val commandReceived = CompletableDeferred<String>()
+
+                launch {
+                    XesarMqttClient.connectAsync(config).await().use { client ->
+                        client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                        client.onMessage = { topic, payload ->
+                            when (topic) {
+                                Topics.Command.ADD_EVVA_COMPONENT -> {
+                                    commandReceived.complete(payload.decodeToString())
+                                }
+                            }
+                        }
+
+                        simulatedBackendReady.complete(Unit)
+
+                        val commandContent = commandReceived.await()
+                        commandContent.shouldBeEqual(
+                            "{\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"id\":\"2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be\",\"type\":\"Cylinder\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+                    }
+                }
+                launch {
+                    simulatedBackendReady.await()
+
+                    XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                        api.subscribeAsync(
+                                Topics(
+                                    Topics.Event.INSTALLATION_POINT_CHANGED,
+                                    Topics.Event.EVVA_COMPONENT_ADDED))
+                            .await()
+
+                        val addEvvaComponentEventPair =
+                            api.addEvvaComponentAsync(
+                                UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"),
+                                ComponentType.Cylinder)
+                        shouldThrow<OptionalEventException> {
+                            addEvvaComponentEventPair.evvaComponentAddedDeferred.await()
+                        }
+                        shouldThrow<RequiredEventException> {
+                            addEvvaComponentEventPair.installationPointChangedDeferred.await()
+                        }
+                    }
+                }
+            }
+        }
+
+        test("add evva component returning an api error") {
+            coEvery { config.uuidGenerator.generateId() }
+                .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+            runBlocking {
+                val simulatedBackendReady = CompletableDeferred<Unit>()
+                val commandReceived = CompletableDeferred<String>()
+
+                launch {
+                    XesarMqttClient.connectAsync(config).await().use { client ->
+                        client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                        client.onMessage = { topic, payload ->
+                            when (topic) {
+                                Topics.Command.ADD_EVVA_COMPONENT -> {
+                                    commandReceived.complete(payload.decodeToString())
+                                }
+                            }
+                        }
+
+                        simulatedBackendReady.complete(Unit)
+
+                        val commandContent = commandReceived.await()
+                        commandContent.shouldBe(
+                            "{\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"id\":\"43edc7cf-80ab-4486-86db-41cda2c7a2cd\",\"type\":\"Cylinder\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+
+                        val apiError =
+                            ApiError(
+                                "reason",
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                123)
+
+                        client
+                            .publishAsync(
+                                Topics.Event.error(config.apiProperties.userId),
+                                encodeError(apiError))
+                            .await()
+                    }
+                }
+                launch {
+                    simulatedBackendReady.await()
+
+                    XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                        api.subscribeAsync(
+                                Topics(
+                                    Topics.Event.INSTALLATION_POINT_CHANGED,
+                                    Topics.Event.EVVA_COMPONENT_ADDED,
+                                    Topics.Event.error(config.apiProperties.userId)))
+                            .await()
+
+                        val addEvvaComponentEventPair =
+                            api.addEvvaComponentAsync(
+                                UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
+                                ComponentType.Cylinder)
+
+                        shouldThrow<OptionalEventException> {
+                            addEvvaComponentEventPair.evvaComponentAddedDeferred.await()
+                        }
+                        shouldThrow<RequiredEventException> {
+                            addEvvaComponentEventPair.installationPointChangedDeferred.await()
+                        }
+
+                        val apiError = addEvvaComponentEventPair.apiErrorDeferred.await()
+                        apiError.get().reason.shouldBe("reason")
+                    }
+                }
+            }
+        }
+
+        test("add evva component returning the required event and an error event") {
+            coEvery { config.uuidGenerator.generateId() }
+                .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+            runBlocking {
+                val simulatedBackendReady = CompletableDeferred<Unit>()
+                val commandReceived = CompletableDeferred<String>()
+
+                launch {
+                    XesarMqttClient.connectAsync(config).await().use { client ->
+                        client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                        client.onMessage = { topic, payload ->
+                            when (topic) {
+                                Topics.Command.ADD_EVVA_COMPONENT -> {
+                                    commandReceived.complete(payload.decodeToString())
+                                }
+                            }
+                        }
+
+                        simulatedBackendReady.complete(Unit)
+
+                        val commandContent = commandReceived.await()
+                        commandContent.shouldBeEqual(
+                            "{\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"id\":\"43edc7cf-80ab-4486-86db-41cda2c7a2cd\",\"type\":\"Cylinder\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+
+                        val apiEvent =
+                            ApiEvent(
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                InstallationPointChanged(
+                                    aggregateId =
+                                        UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd")))
+                        client
+                            .publishAsync(
+                                Topics.Event.INSTALLATION_POINT_CHANGED, encodeEvent(apiEvent))
+                            .await()
+
+                        val apiError =
+                            ApiError(
+                                "reason",
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                123)
+
+                        client
+                            .publishAsync(
+                                Topics.Event.error(config.apiProperties.userId),
+                                encodeError(apiError))
+                            .await()
+                    }
+                }
+                launch {
+                    simulatedBackendReady.await()
+
+                    XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                        api.subscribeAsync(
+                                Topics(
+                                    Topics.Event.INSTALLATION_POINT_CHANGED,
+                                    Topics.Event.EVVA_COMPONENT_ADDED,
+                                    Topics.Event.error(config.apiProperties.userId)))
+                            .await()
+
+                        val addEvvaComponentEventPair =
+                            api.addEvvaComponentAsync(
+                                UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
+                                ComponentType.Cylinder)
+                        val installationPointChanged =
+                            addEvvaComponentEventPair.installationPointChangedDeferred.await()
+                        installationPointChanged.aggregateId.shouldBeEqual(
+                            UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+                        val apiError = addEvvaComponentEventPair.apiErrorDeferred.await()
+                        apiError.get().reason.shouldBe("reason")
+                        shouldThrow<OptionalEventException> {
+                            addEvvaComponentEventPair.evvaComponentAddedDeferred.await()
+                        }
+                    }
+                }
+            }
+        }
+
+        test(
+            "add evva component returning the required event and an error event but switch order of events") {
+                coEvery { config.uuidGenerator.generateId() }
+                    .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+                runBlocking {
+                    val simulatedBackendReady = CompletableDeferred<Unit>()
+                    val commandReceived = CompletableDeferred<String>()
+
+                    launch {
+                        XesarMqttClient.connectAsync(config).await().use { client ->
+                            client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                            client.onMessage = { topic, payload ->
+                                when (topic) {
+                                    Topics.Command.ADD_EVVA_COMPONENT -> {
+                                        commandReceived.complete(payload.decodeToString())
+                                    }
+                                }
+                            }
+
+                            simulatedBackendReady.complete(Unit)
+
+                            val commandContent = commandReceived.await()
+                            commandContent.shouldBeEqual(
+                                "{\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"id\":\"43edc7cf-80ab-4486-86db-41cda2c7a2cd\",\"type\":\"Cylinder\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+
+                            val apiError =
+                                ApiError(
+                                    "reason",
+                                    UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
+                                    123)
+
+                            client
+                                .publishAsync(
+                                    Topics.Event.error(config.apiProperties.userId),
+                                    encodeError(apiError))
+                                .await()
+
+                            val apiEvent =
+                                ApiEvent(
+                                    UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                    InstallationPointChanged(
+                                        aggregateId =
+                                            UUID.fromString(
+                                                "43edc7cf-80ab-4486-86db-41cda2c7a2cd")))
+                            client
+                                .publishAsync(
+                                    Topics.Event.INSTALLATION_POINT_CHANGED, encodeEvent(apiEvent))
+                                .await()
+                        }
+                    }
+                    launch {
+                        simulatedBackendReady.await()
+
+                        XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                            api.subscribeAsync(
+                                    Topics(
+                                        Topics.Event.INSTALLATION_POINT_CHANGED,
+                                        Topics.Event.EVVA_COMPONENT_ADDED,
+                                        Topics.Event.error(config.apiProperties.userId)))
+                                .await()
+
+                            val addEvvaComponentEventPair =
+                                api.addEvvaComponentAsync(
+                                    UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
+                                    ComponentType.Cylinder)
+                            val installationPointChanged =
+                                addEvvaComponentEventPair.installationPointChangedDeferred.await()
+                            installationPointChanged.aggregateId.shouldBeEqual(
+                                UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+                            shouldThrow<OptionalEventException> {
+                                addEvvaComponentEventPair.await()
+                            }
+                        }
+                    }
+                }
+            }
+
+        test("add evva component with wrong publish back to get an Exception") {
+            coEvery { config.uuidGenerator.generateId() }
+                .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+            runBlocking {
+                val simulatedBackendReady = CompletableDeferred<Unit>()
+                val commandReceived = CompletableDeferred<String>()
+
+                launch {
+                    XesarMqttClient.connectAsync(config).await().use { client ->
+                        client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                        client.onMessage = { topic, payload ->
+                            when (topic) {
+                                Topics.Command.ADD_EVVA_COMPONENT -> {
+                                    commandReceived.complete(payload.decodeToString())
+                                }
+                            }
+                        }
+
+                        simulatedBackendReady.complete(Unit)
+
+                        val commandContent = commandReceived.await()
+
+                        commandContent.shouldBeEqual(
+                            "{\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"id\":\"2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be\",\"type\":\"Cylinder\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+
+                        val apiEvent2 =
+                            ApiEvent(
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                EvvaComponentAdded(
+                                    id = UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"),
+                                    evvaComponentId =
+                                        UUID.fromString("3a33c05b-133d-4b9d-a496-5d30dfd2d2c3"),
+                                    type = ComponentType.Cylinder,
+                                    stateChangedAt = LocalDateTime.MIN,
+                                    status = ComponentStatus.AssembledPrepared))
+
+                        client
+                            .publishAsync(
+                                Topics.Event.INSTALLATION_POINT_CHANGED,
+                                "\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\"" /*encodeEvent(apiEvent)*/)
+                            .await()
+
+                        client
+                            .publishAsync(Topics.Event.EVVA_COMPONENT_ADDED, encodeEvent(apiEvent2))
+                            .await()
+                    }
+                }
+                launch {
+                    simulatedBackendReady.await()
+
+                    XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                        api.subscribeAsync(
+                                Topics(
+                                    Topics.Event.INSTALLATION_POINT_CHANGED,
+                                    Topics.Event.EVVA_COMPONENT_ADDED))
+                            .await()
+
+                        val addEvvaComponentEventPair =
+                            api.addEvvaComponentAsync(
+                                UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"),
+                                ComponentType.Cylinder)
+
+                        shouldThrow<ParsingException> {
+                            addEvvaComponentEventPair.installationPointChangedDeferred.await()
+                        }
+                        val evvaComponentAdded =
+                            addEvvaComponentEventPair.evvaComponentAddedDeferred.await()
+                        evvaComponentAdded.type.shouldBe(ComponentType.Cylinder)
+                    }
+                }
+            }
+        }
+
+        test("add evva component returning both events") {
+            coEvery { config.uuidGenerator.generateId() }
+                .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+            runBlocking {
+                val simulatedBackendReady = CompletableDeferred<Unit>()
+                val commandReceived = CompletableDeferred<String>()
+
+                launch {
+                    XesarMqttClient.connectAsync(config).await().use { client ->
+                        client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                        client.onMessage = { topic, payload ->
+                            when (topic) {
+                                Topics.Command.ADD_EVVA_COMPONENT -> {
+                                    commandReceived.complete(payload.decodeToString())
+                                }
+                            }
+                        }
+
+                        simulatedBackendReady.complete(Unit)
+
+                        val commandContent = commandReceived.await()
+
+                        commandContent.shouldBeEqual(
+                            "{\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"id\":\"2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be\",\"type\":\"Cylinder\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+
+                        val apiEvent =
+                            ApiEvent(
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                InstallationPointChanged(
+                                    aggregateId =
+                                        UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd")))
+
+                        val apiEvent2 =
+                            ApiEvent(
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                EvvaComponentAdded(
+                                    id = UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"),
+                                    evvaComponentId =
+                                        UUID.fromString("3a33c05b-133d-4b9d-a496-5d30dfd2d2c3"),
+                                    type = ComponentType.Cylinder,
+                                    stateChangedAt = LocalDateTime.MIN,
+                                    status = ComponentStatus.AssembledPrepared))
+
+                        client
+                            .publishAsync(
+                                Topics.Event.INSTALLATION_POINT_CHANGED, encodeEvent(apiEvent))
+                            .await()
+                        logger.info { "sent installation point changed" }
+
+                        client
+                            .publishAsync(Topics.Event.EVVA_COMPONENT_ADDED, encodeEvent(apiEvent2))
+                            .await()
+
+                        logger.info { "sent evva component added" }
+                    }
+                }
+                launch {
+                    simulatedBackendReady.await()
+
+                    XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                        api.subscribeAsync(
+                                Topics(
+                                    Topics.Event.INSTALLATION_POINT_CHANGED,
+                                    Topics.Event.EVVA_COMPONENT_ADDED))
+                            .await()
+
+                        val addEvvaComponentEventPair =
+                            api.addEvvaComponentAsync(
+                                UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"),
+                                ComponentType.Cylinder)
+                        val test =
+                            addEvvaComponentEventPair.installationPointChangedDeferred.await()
+                        test.aggregateId.shouldBeEqual(
+                            UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+                        val evvaComponentAdded =
+                            addEvvaComponentEventPair.evvaComponentAddedDeferred.await()
+                        evvaComponentAdded.type.shouldBe(ComponentType.Cylinder)
+                    }
+                }
+            }
+        }
+
+        test("add evva component but only required field will be returned") {
+            coEvery { config.uuidGenerator.generateId() }
+                .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+            runBlocking {
+                val simulatedBackendReady = CompletableDeferred<Unit>()
+                val commandReceived = CompletableDeferred<String>()
+
+                launch {
+                    XesarMqttClient.connectAsync(config).await().use { client ->
+                        client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                        client.onMessage = { topic, payload ->
+                            when (topic) {
+                                Topics.Command.ADD_EVVA_COMPONENT -> {
+                                    commandReceived.complete(payload.decodeToString())
+                                }
+                            }
+                        }
+
+                        simulatedBackendReady.complete(Unit)
+
+                        val commandContent = commandReceived.await()
+                        commandContent.shouldBeEqual(
+                            "{\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"id\":\"2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be\",\"type\":\"Cylinder\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+
+                        val apiEvent =
+                            ApiEvent(
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                InstallationPointChanged(
+                                    aggregateId =
+                                        UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd")))
+
+                        client
+                            .publishAsync(
+                                Topics.Event.INSTALLATION_POINT_CHANGED, encodeEvent(apiEvent))
+                            .await()
+                    }
+                }
+                launch {
+                    simulatedBackendReady.await()
+
+                    XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                        api.subscribeAsync(
+                                Topics(
+                                    Topics.Event.INSTALLATION_POINT_CHANGED,
+                                    Topics.Event.EVVA_COMPONENT_ADDED))
+                            .await()
+
+                        val addEvvaComponentEventPair =
+                            api.addEvvaComponentAsync(
+                                UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"),
+                                ComponentType.Cylinder)
+                        val installationPointChanged =
+                            addEvvaComponentEventPair.installationPointChangedDeferred.await()
+                        installationPointChanged.aggregateId.shouldBeEqual(
+                            UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+
+                        shouldThrow<OptionalEventException> {
+                            addEvvaComponentEventPair.evvaComponentAddedDeferred.await()
+                        }
+                    }
+                }
+            }
+        }
+    })

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/AddInstallationPointAuthorizationToMediumTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/AddInstallationPointAuthorizationToMediumTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.addInstallationPointAuthorizationToMedium
+import com.open200.xesar.connect.extension.addInstallationPointAuthorizationToMediumAsync
 import com.open200.xesar.connect.messages.command.AuthorizationData
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.IndividualAuthorizationsAddedToMedium
@@ -78,12 +78,13 @@ class AddInstallationPointAuthorizationToMediumTest :
                                 true,
                                 UUID.fromString("e9b31e62-8969-4794-a219-8c81ff10c91d"))
                         val result =
-                            api.addInstallationPointAuthorizationToMedium(
-                                    UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
-                                    authorizationData)
-                                .await()
-                        result.id.shouldBeEqual(
-                            UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+                            api.addInstallationPointAuthorizationToMediumAsync(
+                                UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
+                                authorizationData)
+                        result
+                            .await()
+                            .id
+                            .shouldBeEqual(UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
                     }
                 }
             }

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/AddInstallationPointToZoneTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/AddInstallationPointToZoneTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.addInstallationPointToZone
+import com.open200.xesar.connect.extension.addInstallationPointToZoneAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.InstallationPointsInZoneChanged
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -71,7 +71,7 @@ class AddInstallationPointToZoneTest :
                         api.subscribeAsync(Topics(Topics.Event.INSTALLATION_POINTS_IN_ZONE_CHANGED))
                             .await()
                         val result =
-                            api.addInstallationPointToZone(
+                            api.addInstallationPointToZoneAsync(
                                     UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
                                     UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"))
                                 .await()

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/AddZoneAuthorizationToMediumTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/AddZoneAuthorizationToMediumTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.addZoneAuthorizationToMedium
+import com.open200.xesar.connect.extension.addZoneAuthorizationToMediumAsync
 import com.open200.xesar.connect.messages.command.AuthorizationData
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.IndividualAuthorizationsAddedToMedium
@@ -78,7 +78,7 @@ class AddZoneAuthorizationToMediumTest :
                                 false,
                                 UUID.fromString("e9b31e62-8969-4794-a219-8c81ff10c91d"))
                         val result =
-                            api.addZoneAuthorizationToMedium(
+                            api.addZoneAuthorizationToMediumAsync(
                                     UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
                                     authorizationData)
                                 .await()

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/AssignAuthorizationProfileToMediumTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/AssignAuthorizationProfileToMediumTest.kt
@@ -1,0 +1,545 @@
+package com.open200.xesar.connect.command
+
+import com.open200.xesar.connect.Topics
+import com.open200.xesar.connect.XesarConnect
+import com.open200.xesar.connect.XesarMqttClient
+import com.open200.xesar.connect.exception.OptionalEventException
+import com.open200.xesar.connect.exception.ParsingException
+import com.open200.xesar.connect.extension.assignAuthorizationProfileToMediumAsync
+import com.open200.xesar.connect.messages.ApiError
+import com.open200.xesar.connect.messages.encodeError
+import com.open200.xesar.connect.messages.event.*
+import com.open200.xesar.connect.testutils.MosquittoContainer
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.common.runBlocking
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.extensions.testcontainers.perProject
+import io.kotest.matchers.equals.shouldBeEqual
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import java.time.LocalDateTime
+import java.util.*
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.launch
+
+class AssignAuthorizationProfileToMediumTest :
+    FunSpec({
+        val container = MosquittoContainer.container()
+        val config = MosquittoContainer.config(container)
+        listener(container.perProject())
+        test("assign authorization profile to medium returning no event") {
+            coEvery { config.uuidGenerator.generateId() }
+                .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+            runBlocking {
+                val simulatedBackendReady = CompletableDeferred<Unit>()
+                val commandReceived = CompletableDeferred<String>()
+
+                launch {
+                    XesarMqttClient.connectAsync(config).await().use { client ->
+                        client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                        client.onMessage = { topic, payload ->
+                            when (topic) {
+                                Topics.Command.ASSIGN_AUTHORIZATION_PROFILE_TO_MEDIUM -> {
+                                    commandReceived.complete(payload.decodeToString())
+                                }
+                            }
+                        }
+
+                        simulatedBackendReady.complete(Unit)
+                        val commandContent = commandReceived.await()
+                        commandContent.shouldBeEqual(
+                            "{\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"authorizationProfileId\":null,\"id\":\"2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+                    }
+                }
+                launch {
+                    simulatedBackendReady.await()
+
+                    XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                        api.subscribeAsync(
+                                Topics(
+                                    Topics.Event.MEDIUM_CHANGED,
+                                    Topics.Event.MEDIUM_AUTHORIZATION_PROFILE_CHANGED))
+                            .await()
+
+                        val assignAuthorizationProfileToMediumResult =
+                            api.assignAuthorizationProfileToMediumAsync(
+                                UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"),
+                            )
+                        shouldThrow<OptionalEventException> {
+                            assignAuthorizationProfileToMediumResult.mediumChangedDeferred.await()
+                        }
+                        shouldThrow<OptionalEventException> {
+                            assignAuthorizationProfileToMediumResult
+                                .mediumAuthorizationProfileChangedDeferred
+                                .await()
+                        }
+                    }
+                }
+            }
+        }
+
+        test("assign authorization profile to medium returning an api error") {
+            coEvery { config.uuidGenerator.generateId() }
+                .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+            runBlocking {
+                val simulatedBackendReady = CompletableDeferred<Unit>()
+                val commandReceived = CompletableDeferred<String>()
+
+                launch {
+                    XesarMqttClient.connectAsync(config).await().use { client ->
+                        client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                        client.onMessage = { topic, payload ->
+                            when (topic) {
+                                Topics.Command.ASSIGN_AUTHORIZATION_PROFILE_TO_MEDIUM -> {
+                                    commandReceived.complete(payload.decodeToString())
+                                }
+                            }
+                        }
+
+                        simulatedBackendReady.complete(Unit)
+
+                        val commandContent = commandReceived.await()
+                        commandContent.shouldBe(
+                            "{\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"authorizationProfileId\":null,\"id\":\"43edc7cf-80ab-4486-86db-41cda2c7a2cd\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+
+                        val apiError =
+                            ApiError(
+                                "reason",
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                123)
+
+                        client
+                            .publishAsync(
+                                Topics.Event.error(config.apiProperties.userId),
+                                encodeError(apiError))
+                            .await()
+                    }
+                }
+                launch {
+                    simulatedBackendReady.await()
+
+                    XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                        api.subscribeAsync(
+                                Topics(
+                                    Topics.Event.MEDIUM_CHANGED,
+                                    Topics.Event.MEDIUM_AUTHORIZATION_PROFILE_CHANGED,
+                                    Topics.Event.error(config.apiProperties.userId)))
+                            .await()
+
+                        val assignAuthorizationProfileToMediumResult =
+                            api.assignAuthorizationProfileToMediumAsync(
+                                UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
+                            )
+
+                        shouldThrow<OptionalEventException> {
+                            assignAuthorizationProfileToMediumResult.mediumChangedDeferred.await()
+                        }
+                        shouldThrow<OptionalEventException> {
+                            assignAuthorizationProfileToMediumResult
+                                .mediumAuthorizationProfileChangedDeferred
+                                .await()
+                        }
+
+                        val apiError =
+                            assignAuthorizationProfileToMediumResult.apiErrorDeferred.await()
+                        apiError.get().reason.shouldBe("reason")
+                    }
+                }
+            }
+        }
+
+        test("assign authorization profile to medium returning one event and an error event") {
+            coEvery { config.uuidGenerator.generateId() }
+                .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+            runBlocking {
+                val simulatedBackendReady = CompletableDeferred<Unit>()
+                val commandReceived = CompletableDeferred<String>()
+
+                launch {
+                    XesarMqttClient.connectAsync(config).await().use { client ->
+                        client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                        client.onMessage = { topic, payload ->
+                            when (topic) {
+                                Topics.Command.ASSIGN_AUTHORIZATION_PROFILE_TO_MEDIUM -> {
+                                    commandReceived.complete(payload.decodeToString())
+                                }
+                            }
+                        }
+
+                        simulatedBackendReady.complete(Unit)
+
+                        val commandContent = commandReceived.await()
+                        commandContent.shouldBeEqual(
+                            "{\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"authorizationProfileId\":null,\"id\":\"43edc7cf-80ab-4486-86db-41cda2c7a2cd\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+
+                        val apiEvent =
+                            ApiEvent(
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                MediumChanged(
+                                    id = UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
+                                    accessBeginAt =
+                                        LocalDateTime.parse("2023-08-24T16:25:52.225991"),
+                                    changedAt = LocalDateTime.parse("2023-08-23T16:25:52.225991")))
+                        client
+                            .publishAsync(Topics.Event.MEDIUM_CHANGED, encodeEvent(apiEvent))
+                            .await()
+
+                        val apiError =
+                            ApiError(
+                                "reason",
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                123)
+
+                        client
+                            .publishAsync(
+                                Topics.Event.error(config.apiProperties.userId),
+                                encodeError(apiError))
+                            .await()
+                    }
+                }
+                launch {
+                    simulatedBackendReady.await()
+
+                    XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                        api.subscribeAsync(
+                                Topics(
+                                    Topics.Event.MEDIUM_CHANGED,
+                                    Topics.Event.MEDIUM_AUTHORIZATION_PROFILE_CHANGED,
+                                    Topics.Event.error(config.apiProperties.userId)))
+                            .await()
+
+                        val assignAuthorizationProfileToMediumResult =
+                            api.assignAuthorizationProfileToMediumAsync(
+                                UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
+                            )
+                        val mediumChanged =
+                            assignAuthorizationProfileToMediumResult.mediumChangedDeferred.await()
+                        mediumChanged.id.shouldBeEqual(
+                            UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+                        val apiError =
+                            assignAuthorizationProfileToMediumResult.apiErrorDeferred.await()
+                        apiError.get().reason.shouldBe("reason")
+                        shouldThrow<OptionalEventException> {
+                            assignAuthorizationProfileToMediumResult
+                                .mediumAuthorizationProfileChangedDeferred
+                                .await()
+                        }
+                    }
+                }
+            }
+        }
+
+        test(
+            "assign authorization profile to medium returning one event and an error event but switch order of events") {
+                coEvery { config.uuidGenerator.generateId() }
+                    .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+                runBlocking {
+                    val simulatedBackendReady = CompletableDeferred<Unit>()
+                    val commandReceived = CompletableDeferred<String>()
+
+                    launch {
+                        XesarMqttClient.connectAsync(config).await().use { client ->
+                            client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                            client.onMessage = { topic, payload ->
+                                when (topic) {
+                                    Topics.Command.ASSIGN_AUTHORIZATION_PROFILE_TO_MEDIUM -> {
+                                        commandReceived.complete(payload.decodeToString())
+                                    }
+                                }
+                            }
+
+                            simulatedBackendReady.complete(Unit)
+
+                            val commandContent = commandReceived.await()
+                            commandContent.shouldBeEqual(
+                                "{\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"authorizationProfileId\":null,\"id\":\"43edc7cf-80ab-4486-86db-41cda2c7a2cd\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+
+                            val apiError =
+                                ApiError(
+                                    "reason",
+                                    UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
+                                    123)
+
+                            client
+                                .publishAsync(
+                                    Topics.Event.error(config.apiProperties.userId),
+                                    encodeError(apiError))
+                                .await()
+
+                            val apiEvent =
+                                ApiEvent(
+                                    UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                    MediumAuthorizationProfileChanged(
+                                        id =
+                                            UUID.fromString(
+                                                "43edc7cf-80ab-4486-86db-41cda2c7a2cd")))
+                            client
+                                .publishAsync(
+                                    Topics.Event.MEDIUM_AUTHORIZATION_PROFILE_CHANGED,
+                                    encodeEvent(apiEvent))
+                                .await()
+                        }
+                    }
+                    launch {
+                        simulatedBackendReady.await()
+
+                        XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                            api.subscribeAsync(
+                                    Topics(
+                                        Topics.Event.MEDIUM_CHANGED,
+                                        Topics.Event.MEDIUM_AUTHORIZATION_PROFILE_CHANGED,
+                                        Topics.Event.error(config.apiProperties.userId)))
+                                .await()
+
+                            val assignAuthorizationProfileToMediumResult =
+                                api.assignAuthorizationProfileToMediumAsync(
+                                    UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
+                                )
+                            val MediumAuthorizationProfileChanged =
+                                assignAuthorizationProfileToMediumResult
+                                    .mediumAuthorizationProfileChangedDeferred
+                                    .await()
+                            MediumAuthorizationProfileChanged.id.shouldBeEqual(
+                                UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+                            shouldThrow<OptionalEventException> {
+                                assignAuthorizationProfileToMediumResult.await()
+                            }
+                        }
+                    }
+                }
+            }
+
+        test("assign autorization profile to medium with wrong publish back to get an Exception") {
+            coEvery { config.uuidGenerator.generateId() }
+                .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+            runBlocking {
+                val simulatedBackendReady = CompletableDeferred<Unit>()
+                val commandReceived = CompletableDeferred<String>()
+
+                launch {
+                    XesarMqttClient.connectAsync(config).await().use { client ->
+                        client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                        client.onMessage = { topic, payload ->
+                            when (topic) {
+                                Topics.Command.ASSIGN_AUTHORIZATION_PROFILE_TO_MEDIUM -> {
+                                    commandReceived.complete(payload.decodeToString())
+                                }
+                            }
+                        }
+
+                        simulatedBackendReady.complete(Unit)
+
+                        val commandContent = commandReceived.await()
+
+                        commandContent.shouldBeEqual(
+                            "{\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"authorizationProfileId\":null,\"id\":\"2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+
+                        val apiEvent2 =
+                            ApiEvent(
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                MediumChanged(
+                                    id = UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
+                                    accessBeginAt =
+                                        LocalDateTime.parse("2023-08-24T16:25:52.225991"),
+                                    changedAt = LocalDateTime.parse("2023-08-23T16:25:52.225991")))
+
+                        client
+                            .publishAsync(
+                                Topics.Event.MEDIUM_CHANGED,
+                                "\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\"" /*encodeEvent(apiEvent)*/)
+                            .await()
+
+                        client
+                            .publishAsync(
+                                Topics.Event.MEDIUM_AUTHORIZATION_PROFILE_CHANGED,
+                                encodeEvent(apiEvent2))
+                            .await()
+                    }
+                }
+                launch {
+                    simulatedBackendReady.await()
+
+                    XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                        api.subscribeAsync(
+                                Topics(
+                                    Topics.Event.MEDIUM_CHANGED,
+                                    Topics.Event.MEDIUM_AUTHORIZATION_PROFILE_CHANGED))
+                            .await()
+
+                        val assignAuthorizationProfileToMediumResult =
+                            api.assignAuthorizationProfileToMediumAsync(
+                                UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"),
+                            )
+
+                        shouldThrow<ParsingException> {
+                            assignAuthorizationProfileToMediumResult.mediumChangedDeferred.await()
+                        }
+                        val mediumAuthorizationProfilechanged =
+                            assignAuthorizationProfileToMediumResult
+                                .mediumAuthorizationProfileChangedDeferred
+                                .await()
+                        mediumAuthorizationProfilechanged.id.shouldBeEqual(
+                            UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+                    }
+                }
+            }
+        }
+
+        test("assign authorization profile to medium returning both events") {
+            coEvery { config.uuidGenerator.generateId() }
+                .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+            runBlocking {
+                val simulatedBackendReady = CompletableDeferred<Unit>()
+                val commandReceived = CompletableDeferred<String>()
+
+                launch {
+                    XesarMqttClient.connectAsync(config).await().use { client ->
+                        client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                        client.onMessage = { topic, payload ->
+                            when (topic) {
+                                Topics.Command.ASSIGN_AUTHORIZATION_PROFILE_TO_MEDIUM -> {
+                                    commandReceived.complete(payload.decodeToString())
+                                }
+                            }
+                        }
+
+                        simulatedBackendReady.complete(Unit)
+
+                        val commandContent = commandReceived.await()
+
+                        commandContent.shouldBeEqual(
+                            "{\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"authorizationProfileId\":null,\"id\":\"2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+
+                        val apiEvent2 =
+                            ApiEvent(
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                MediumAuthorizationProfileChanged(
+                                    id = UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd")))
+
+                        val apiEvent =
+                            ApiEvent(
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                MediumChanged(
+                                    id = UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
+                                    accessBeginAt =
+                                        LocalDateTime.parse("2023-08-24T16:25:52.225991"),
+                                    changedAt = LocalDateTime.parse("2023-08-23T16:25:52.225991")))
+
+                        client
+                            .publishAsync(Topics.Event.MEDIUM_CHANGED, encodeEvent(apiEvent))
+                            .await()
+
+                        client
+                            .publishAsync(
+                                Topics.Event.MEDIUM_AUTHORIZATION_PROFILE_CHANGED,
+                                encodeEvent(apiEvent2))
+                            .await()
+                    }
+                }
+                launch {
+                    simulatedBackendReady.await()
+
+                    XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                        api.subscribeAsync(
+                                Topics(
+                                    Topics.Event.MEDIUM_CHANGED,
+                                    Topics.Event.MEDIUM_AUTHORIZATION_PROFILE_CHANGED))
+                            .await()
+
+                        val assignAuthorizationProfileToMediumResult =
+                            api.assignAuthorizationProfileToMediumAsync(
+                                UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"),
+                            )
+                        val test =
+                            assignAuthorizationProfileToMediumResult
+                                .mediumAuthorizationProfileChangedDeferred
+                                .await()
+                        test.id.shouldBeEqual(
+                            UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+                        val mediumChanged =
+                            assignAuthorizationProfileToMediumResult.mediumChangedDeferred.await()
+                        mediumChanged.id.shouldBeEqual(
+                            UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+                    }
+                }
+            }
+        }
+
+        test(
+            "assign authorization profile to medium but only one optional field will be returned") {
+                coEvery { config.uuidGenerator.generateId() }
+                    .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+                runBlocking {
+                    val simulatedBackendReady = CompletableDeferred<Unit>()
+                    val commandReceived = CompletableDeferred<String>()
+
+                    launch {
+                        XesarMqttClient.connectAsync(config).await().use { client ->
+                            client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                            client.onMessage = { topic, payload ->
+                                when (topic) {
+                                    Topics.Command.ASSIGN_AUTHORIZATION_PROFILE_TO_MEDIUM -> {
+                                        commandReceived.complete(payload.decodeToString())
+                                    }
+                                }
+                            }
+
+                            simulatedBackendReady.complete(Unit)
+
+                            val commandContent = commandReceived.await()
+                            commandContent.shouldBeEqual(
+                                "{\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"authorizationProfileId\":null,\"id\":\"2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+
+                            val apiEvent =
+                                ApiEvent(
+                                    UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                    MediumChanged(
+                                        id =
+                                            UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
+                                        accessBeginAt =
+                                            LocalDateTime.parse("2023-08-24T16:25:52.225991"),
+                                        changedAt =
+                                            LocalDateTime.parse("2023-08-23T16:25:52.225991")))
+
+                            client
+                                .publishAsync(Topics.Event.MEDIUM_CHANGED, encodeEvent(apiEvent))
+                                .await()
+                        }
+                    }
+                    launch {
+                        simulatedBackendReady.await()
+
+                        XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                            api.subscribeAsync(
+                                    Topics(
+                                        Topics.Event.MEDIUM_CHANGED,
+                                        Topics.Event.MEDIUM_AUTHORIZATION_PROFILE_CHANGED))
+                                .await()
+
+                            val assignAuthorizationProfileToMediumResult =
+                                api.assignAuthorizationProfileToMediumAsync(
+                                    UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"),
+                                )
+                            val mediumAuthorizationProfileChanged =
+                                assignAuthorizationProfileToMediumResult.mediumChangedDeferred
+                                    .await()
+                            mediumAuthorizationProfileChanged.id.shouldBeEqual(
+                                UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+
+                            shouldThrow<OptionalEventException> {
+                                assignAuthorizationProfileToMediumResult
+                                    .mediumAuthorizationProfileChangedDeferred
+                                    .await()
+                            }
+                        }
+                    }
+                }
+            }
+    })

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/AssignPersonToMediumTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/AssignPersonToMediumTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.assignPersonToMedium
+import com.open200.xesar.connect.extension.assignPersonToMediumAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.MediumPersonChanged
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -68,7 +68,7 @@ class AssignPersonToMediumTest :
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.MEDIUM_PERSON_CHANGED)).await()
                         val result =
-                            api.assignPersonToMedium(
+                            api.assignPersonToMediumAsync(
                                     UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
                                     UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"))
                                 .await()

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/ChangeAuthorizationProfileTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/ChangeAuthorizationProfileTest.kt
@@ -1,0 +1,626 @@
+package com.open200.xesar.connect.command
+
+import com.open200.xesar.connect.Topics
+import com.open200.xesar.connect.XesarConnect
+import com.open200.xesar.connect.XesarMqttClient
+import com.open200.xesar.connect.exception.OptionalEventException
+import com.open200.xesar.connect.exception.ParsingException
+import com.open200.xesar.connect.exception.RequiredEventException
+import com.open200.xesar.connect.extension.changeAuthorizationProfileAsync
+import com.open200.xesar.connect.messages.ApiError
+import com.open200.xesar.connect.messages.encodeError
+import com.open200.xesar.connect.messages.event.*
+import com.open200.xesar.connect.testutils.MosquittoContainer
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.common.runBlocking
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.extensions.testcontainers.perProject
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.equals.shouldBeEqual
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import java.util.*
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.launch
+
+class ChangeAuthorizationProfileTest :
+    FunSpec({
+        val container = MosquittoContainer.container()
+        val config = MosquittoContainer.config(container)
+        listener(container.perProject())
+        test("change authorization profile returning no event") {
+            coEvery { config.uuidGenerator.generateId() }
+                .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+            runBlocking {
+                val simulatedBackendReady = CompletableDeferred<Unit>()
+                val commandReceived = CompletableDeferred<String>()
+
+                launch {
+                    XesarMqttClient.connectAsync(config).await().use { client ->
+                        client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                        client.onMessage = { topic, payload ->
+                            when (topic) {
+                                Topics.Command.CHANGE_AUTHORIZATION_PROFILE -> {
+                                    commandReceived.complete(payload.decodeToString())
+                                }
+                            }
+                        }
+
+                        simulatedBackendReady.complete(Unit)
+
+                        val commandContent = commandReceived.await()
+                        commandContent.shouldBeEqual(
+                            "{\"installationPoints\":[],\"manualOfficeMode\":true,\"name\":\"new name\",\"description\":\"new description\",\"standardTimeProfile\":null,\"id\":\"2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be\",\"zones\":[],\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+                    }
+                }
+                launch {
+                    simulatedBackendReady.await()
+
+                    XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                        api.subscribeAsync(
+                                Topics(
+                                    Topics.Event.AUTHORIZATION_PROFILE_CHANGED,
+                                    Topics.Event.AUTHORIZATION_PROFILE_ACCESS_CHANGED,
+                                    Topics.Event.AUTHORIZATION_PROFILE_INFO_CHANGED))
+                            .await()
+
+                        val changeAuthorizationProfileResult =
+                            api.changeAuthorizationProfileAsync(
+                                emptyList(),
+                                true,
+                                "new name",
+                                "new description",
+                                null,
+                                UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"),
+                                emptyList())
+
+                        shouldThrow<OptionalEventException> {
+                            changeAuthorizationProfileResult
+                                .authorizationProfileAccessChangedDeferred
+                                .await()
+                        }
+                        shouldThrow<OptionalEventException> {
+                            changeAuthorizationProfileResult.authorizationProfileChangedDeferred
+                                .await()
+                        }
+                        shouldThrow<RequiredEventException> {
+                            changeAuthorizationProfileResult.authorizationProfileInfoChangedDeferred
+                                .await()
+                        }
+                        changeAuthorizationProfileResult.apiErrorDeferred
+                            .await()
+                            .isPresent()
+                            .shouldBeFalse()
+                    }
+                }
+            }
+        }
+
+        test("change authorization profile returning an api error") {
+            coEvery { config.uuidGenerator.generateId() }
+                .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+            runBlocking {
+                val simulatedBackendReady = CompletableDeferred<Unit>()
+                val commandReceived = CompletableDeferred<String>()
+
+                launch {
+                    XesarMqttClient.connectAsync(config).await().use { client ->
+                        client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                        client.onMessage = { topic, payload ->
+                            when (topic) {
+                                Topics.Command.CHANGE_AUTHORIZATION_PROFILE -> {
+                                    commandReceived.complete(payload.decodeToString())
+                                }
+                            }
+                        }
+
+                        simulatedBackendReady.complete(Unit)
+
+                        val commandContent = commandReceived.await()
+                        commandContent.shouldBe(
+                            "{\"installationPoints\":[],\"manualOfficeMode\":true,\"name\":\"new name\",\"description\":\"new description\",\"standardTimeProfile\":null,\"id\":\"2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be\",\"zones\":[],\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+
+                        val apiError =
+                            ApiError(
+                                "reason",
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                123)
+
+                        client
+                            .publishAsync(
+                                Topics.Event.error(config.apiProperties.userId),
+                                encodeError(apiError))
+                            .await()
+                    }
+                }
+                launch {
+                    simulatedBackendReady.await()
+
+                    XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                        api.subscribeAsync(
+                                Topics(
+                                    Topics.Event.AUTHORIZATION_PROFILE_CHANGED,
+                                    Topics.Event.AUTHORIZATION_PROFILE_ACCESS_CHANGED,
+                                    Topics.Event.AUTHORIZATION_PROFILE_INFO_CHANGED))
+                            .await()
+
+                        val changeAuthorizationProfileResult =
+                            api.changeAuthorizationProfileAsync(
+                                emptyList(),
+                                true,
+                                "new name",
+                                "new description",
+                                null,
+                                UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"),
+                                emptyList())
+
+                        shouldThrow<OptionalEventException> {
+                            changeAuthorizationProfileResult
+                                .authorizationProfileAccessChangedDeferred
+                                .await()
+                        }
+                        shouldThrow<OptionalEventException> {
+                            changeAuthorizationProfileResult.authorizationProfileChangedDeferred
+                                .await()
+                        }
+                        shouldThrow<RequiredEventException> {
+                            changeAuthorizationProfileResult.authorizationProfileInfoChangedDeferred
+                                .await()
+                        }
+
+                        val apiError = changeAuthorizationProfileResult.apiErrorDeferred.await()
+                        apiError.get().reason.shouldBe("reason")
+                    }
+                }
+            }
+        }
+
+        test("change authorization profile returning the required event and an error event") {
+            coEvery { config.uuidGenerator.generateId() }
+                .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+            runBlocking {
+                val simulatedBackendReady = CompletableDeferred<Unit>()
+                val commandReceived = CompletableDeferred<String>()
+
+                launch {
+                    XesarMqttClient.connectAsync(config).await().use { client ->
+                        client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                        client.onMessage = { topic, payload ->
+                            when (topic) {
+                                Topics.Command.CHANGE_AUTHORIZATION_PROFILE -> {
+                                    commandReceived.complete(payload.decodeToString())
+                                }
+                            }
+                        }
+
+                        simulatedBackendReady.complete(Unit)
+
+                        val commandContent = commandReceived.await()
+                        commandContent.shouldBeEqual(
+                            "{\"installationPoints\":[],\"manualOfficeMode\":true,\"name\":\"new name\",\"description\":\"new description\",\"standardTimeProfile\":null,\"id\":\"2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be\",\"zones\":[],\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+
+                        val apiEvent =
+                            ApiEvent(
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                AuthorizationProfileInfoChanged(
+                                    id = UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd")))
+                        client
+                            .publishAsync(
+                                Topics.Event.AUTHORIZATION_PROFILE_INFO_CHANGED,
+                                encodeEvent(apiEvent))
+                            .await()
+
+                        val apiError =
+                            ApiError(
+                                "reason",
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                123)
+
+                        client
+                            .publishAsync(
+                                Topics.Event.error(config.apiProperties.userId),
+                                encodeError(apiError))
+                            .await()
+                    }
+                }
+                launch {
+                    simulatedBackendReady.await()
+
+                    XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                        api.subscribeAsync(
+                                Topics(
+                                    Topics.Event.AUTHORIZATION_PROFILE_CHANGED,
+                                    Topics.Event.AUTHORIZATION_PROFILE_ACCESS_CHANGED,
+                                    Topics.Event.AUTHORIZATION_PROFILE_INFO_CHANGED))
+                            .await()
+
+                        val changeAuthorizationProfileResult =
+                            api.changeAuthorizationProfileAsync(
+                                emptyList(),
+                                true,
+                                "new name",
+                                "new description",
+                                null,
+                                UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"),
+                                emptyList())
+                        val authorizationProfileInfoChanged =
+                            changeAuthorizationProfileResult.authorizationProfileInfoChangedDeferred
+                                .await()
+                        authorizationProfileInfoChanged.id.shouldBe(
+                            UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+                        val apiError = changeAuthorizationProfileResult.apiErrorDeferred.await()
+                        apiError.get().reason.shouldBe("reason")
+                        shouldThrow<OptionalEventException> {
+                            changeAuthorizationProfileResult.authorizationProfileChangedDeferred
+                                .await()
+                        }
+                        shouldThrow<OptionalEventException> {
+                            changeAuthorizationProfileResult
+                                .authorizationProfileAccessChangedDeferred
+                                .await()
+                        }
+                    }
+                }
+            }
+        }
+
+        test(
+            "change authorization profile returning the required event and an error event but switch order of events") {
+                coEvery { config.uuidGenerator.generateId() }
+                    .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+                runBlocking {
+                    val simulatedBackendReady = CompletableDeferred<Unit>()
+                    val commandReceived = CompletableDeferred<String>()
+
+                    launch {
+                        XesarMqttClient.connectAsync(config).await().use { client ->
+                            client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                            client.onMessage = { topic, payload ->
+                                when (topic) {
+                                    Topics.Command.CHANGE_AUTHORIZATION_PROFILE -> {
+                                        commandReceived.complete(payload.decodeToString())
+                                    }
+                                }
+                            }
+
+                            simulatedBackendReady.complete(Unit)
+
+                            val commandContent = commandReceived.await()
+                            commandContent.shouldBeEqual(
+                                "{\"installationPoints\":[],\"manualOfficeMode\":true,\"name\":\"new name\",\"description\":\"new description\",\"standardTimeProfile\":null,\"id\":\"2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be\",\"zones\":[],\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+
+                            val apiError =
+                                ApiError(
+                                    "reason",
+                                    UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                    123)
+
+                            client
+                                .publishAsync(
+                                    Topics.Event.error(config.apiProperties.userId),
+                                    encodeError(apiError))
+                                .await()
+
+                            val apiEvent =
+                                ApiEvent(
+                                    UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                    AuthorizationProfileInfoChanged(
+                                        id =
+                                            UUID.fromString(
+                                                "43edc7cf-80ab-4486-86db-41cda2c7a2cd")))
+                            client
+                                .publishAsync(
+                                    Topics.Event.AUTHORIZATION_PROFILE_INFO_CHANGED,
+                                    encodeEvent(apiEvent))
+                                .await()
+                        }
+                    }
+                    launch {
+                        simulatedBackendReady.await()
+
+                        XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                            api.subscribeAsync(
+                                    Topics(
+                                        Topics.Event.AUTHORIZATION_PROFILE_CHANGED,
+                                        Topics.Event.AUTHORIZATION_PROFILE_ACCESS_CHANGED,
+                                        Topics.Event.AUTHORIZATION_PROFILE_INFO_CHANGED))
+                                .await()
+
+                            val changeAuthorizationProfileResult =
+                                api.changeAuthorizationProfileAsync(
+                                    emptyList(),
+                                    true,
+                                    "new name",
+                                    "new description",
+                                    null,
+                                    UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"),
+                                    emptyList())
+                            val authorizationProfileInfoChanged =
+                                changeAuthorizationProfileResult
+                                    .authorizationProfileInfoChangedDeferred
+                                    .await()
+                            authorizationProfileInfoChanged.id.shouldBe(
+                                UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+                            shouldThrow<OptionalEventException> {
+                                changeAuthorizationProfileResult.authorizationProfileChangedDeferred
+                                    .await()
+                            }
+                            shouldThrow<OptionalEventException> {
+                                changeAuthorizationProfileResult
+                                    .authorizationProfileAccessChangedDeferred
+                                    .await()
+                            }
+                            val apiError = changeAuthorizationProfileResult.apiErrorDeferred.await()
+                            apiError.get().reason.shouldBe("reason")
+                        }
+                    }
+                }
+            }
+
+        test("change authorization profile with wrong publish back to get an Exception") {
+            coEvery { config.uuidGenerator.generateId() }
+                .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+            runBlocking {
+                val simulatedBackendReady = CompletableDeferred<Unit>()
+                val commandReceived = CompletableDeferred<String>()
+
+                launch {
+                    XesarMqttClient.connectAsync(config).await().use { client ->
+                        client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                        client.onMessage = { topic, payload ->
+                            when (topic) {
+                                Topics.Command.CHANGE_AUTHORIZATION_PROFILE -> {
+                                    commandReceived.complete(payload.decodeToString())
+                                }
+                            }
+                        }
+
+                        simulatedBackendReady.complete(Unit)
+
+                        val commandContent = commandReceived.await()
+
+                        commandContent.shouldBeEqual(
+                            "{\"installationPoints\":[],\"manualOfficeMode\":true,\"name\":\"new name\",\"description\":\"new description\",\"standardTimeProfile\":null,\"id\":\"2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be\",\"zones\":[],\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+
+                        val apiEvent2 =
+                            ApiEvent(
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                AuthorizationProfileInfoChanged(
+                                    id = UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd")))
+
+                        client
+                            .publishAsync(
+                                Topics.Event.AUTHORIZATION_PROFILE_ACCESS_CHANGED,
+                                "\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\"" /*encodeEvent(apiEvent)*/)
+                            .await()
+
+                        client
+                            .publishAsync(
+                                Topics.Event.AUTHORIZATION_PROFILE_INFO_CHANGED,
+                                encodeEvent(apiEvent2))
+                            .await()
+                    }
+                }
+                launch {
+                    simulatedBackendReady.await()
+
+                    XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                        api.subscribeAsync(
+                                Topics(
+                                    Topics.Event.AUTHORIZATION_PROFILE_CHANGED,
+                                    Topics.Event.AUTHORIZATION_PROFILE_ACCESS_CHANGED,
+                                    Topics.Event.AUTHORIZATION_PROFILE_INFO_CHANGED))
+                            .await()
+
+                        val changeAuthorizationProfileResult =
+                            api.changeAuthorizationProfileAsync(
+                                emptyList(),
+                                true,
+                                "new name",
+                                "new description",
+                                null,
+                                UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"),
+                                emptyList())
+
+                        shouldThrow<ParsingException> {
+                            changeAuthorizationProfileResult
+                                .authorizationProfileAccessChangedDeferred
+                                .await()
+                        }
+                        val authorizationProfileInfoChanged =
+                            changeAuthorizationProfileResult.authorizationProfileInfoChangedDeferred
+                                .await()
+                        authorizationProfileInfoChanged.id.shouldBe(
+                            UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+                    }
+                }
+            }
+        }
+
+        test("change authorization profile returning all events") {
+            coEvery { config.uuidGenerator.generateId() }
+                .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+            runBlocking {
+                val simulatedBackendReady = CompletableDeferred<Unit>()
+                val commandReceived = CompletableDeferred<String>()
+
+                launch {
+                    XesarMqttClient.connectAsync(config).await().use { client ->
+                        client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                        client.onMessage = { topic, payload ->
+                            when (topic) {
+                                Topics.Command.CHANGE_AUTHORIZATION_PROFILE -> {
+                                    commandReceived.complete(payload.decodeToString())
+                                }
+                            }
+                        }
+
+                        simulatedBackendReady.complete(Unit)
+
+                        val commandContent = commandReceived.await()
+
+                        commandContent.shouldBeEqual(
+                            "{\"installationPoints\":[],\"manualOfficeMode\":true,\"name\":\"new name\",\"description\":\"new description\",\"standardTimeProfile\":null,\"id\":\"2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be\",\"zones\":[],\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+
+                        val apiEvent =
+                            ApiEvent(
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                AuthorizationProfileChanged(
+                                    id = UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd")))
+
+                        val apiEvent2 =
+                            ApiEvent(
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                AuthorizationProfileAccessChanged(
+                                    id = UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd")))
+                        val apiEvent3 =
+                            ApiEvent(
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                AuthorizationProfileInfoChanged(
+                                    id = UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd")))
+
+                        client
+                            .publishAsync(
+                                Topics.Event.AUTHORIZATION_PROFILE_CHANGED, encodeEvent(apiEvent))
+                            .await()
+
+                        client
+                            .publishAsync(
+                                Topics.Event.AUTHORIZATION_PROFILE_ACCESS_CHANGED,
+                                encodeEvent(apiEvent2))
+                            .await()
+
+                        client
+                            .publishAsync(
+                                Topics.Event.AUTHORIZATION_PROFILE_INFO_CHANGED,
+                                encodeEvent(apiEvent3))
+                            .await()
+                    }
+                }
+                launch {
+                    simulatedBackendReady.await()
+
+                    XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                        api.subscribeAsync(
+                                Topics(
+                                    Topics.Event.AUTHORIZATION_PROFILE_CHANGED,
+                                    Topics.Event.AUTHORIZATION_PROFILE_ACCESS_CHANGED,
+                                    Topics.Event.AUTHORIZATION_PROFILE_INFO_CHANGED))
+                            .await()
+
+                        val changeAuthorizationProfileResult =
+                            api.changeAuthorizationProfileAsync(
+                                emptyList(),
+                                true,
+                                "new name",
+                                "new description",
+                                null,
+                                UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"),
+                                emptyList())
+                        val authorizationProfileInfoChanged =
+                            changeAuthorizationProfileResult.authorizationProfileInfoChangedDeferred
+                                .await()
+
+                        authorizationProfileInfoChanged.id.shouldBe(
+                            UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+                        val authorizationProfileChanged =
+                            changeAuthorizationProfileResult.authorizationProfileChangedDeferred
+                                .await()
+                        authorizationProfileChanged.id.shouldBe(
+                            UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+
+                        val authorizationProfileAccessChanged =
+                            changeAuthorizationProfileResult
+                                .authorizationProfileAccessChangedDeferred
+                                .await()
+                        authorizationProfileAccessChanged.id.shouldBe(
+                            UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+                    }
+                }
+            }
+        }
+
+        test("change authorization profile but only required event will be returned") {
+            coEvery { config.uuidGenerator.generateId() }
+                .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+            runBlocking {
+                val simulatedBackendReady = CompletableDeferred<Unit>()
+                val commandReceived = CompletableDeferred<String>()
+
+                launch {
+                    XesarMqttClient.connectAsync(config).await().use { client ->
+                        client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                        client.onMessage = { topic, payload ->
+                            when (topic) {
+                                Topics.Command.CHANGE_AUTHORIZATION_PROFILE -> {
+                                    commandReceived.complete(payload.decodeToString())
+                                }
+                            }
+                        }
+
+                        simulatedBackendReady.complete(Unit)
+
+                        val commandContent = commandReceived.await()
+                        commandContent.shouldBeEqual(
+                            "{\"installationPoints\":[],\"manualOfficeMode\":true,\"name\":\"new name\",\"description\":\"new description\",\"standardTimeProfile\":null,\"id\":\"2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be\",\"zones\":[],\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+
+                        val apiEvent =
+                            ApiEvent(
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                AuthorizationProfileInfoChanged(
+                                    id = UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd")))
+
+                        client
+                            .publishAsync(
+                                Topics.Event.AUTHORIZATION_PROFILE_INFO_CHANGED,
+                                encodeEvent(apiEvent))
+                            .await()
+                    }
+                }
+                launch {
+                    simulatedBackendReady.await()
+
+                    XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                        api.subscribeAsync(
+                                Topics(
+                                    Topics.Event.AUTHORIZATION_PROFILE_CHANGED,
+                                    Topics.Event.AUTHORIZATION_PROFILE_ACCESS_CHANGED,
+                                    Topics.Event.AUTHORIZATION_PROFILE_INFO_CHANGED))
+                            .await()
+
+                        val changeAuthorizationProfileResult =
+                            api.changeAuthorizationProfileAsync(
+                                emptyList(),
+                                true,
+                                "new name",
+                                "new description",
+                                null,
+                                UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"),
+                                emptyList())
+                        val authorizationProfileInfoChanged =
+                            changeAuthorizationProfileResult.authorizationProfileInfoChangedDeferred
+                                .await()
+                        authorizationProfileInfoChanged.id.shouldBe(
+                            UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+
+                        shouldThrow<OptionalEventException> {
+                            changeAuthorizationProfileResult
+                                .authorizationProfileAccessChangedDeferred
+                                .await()
+                        }
+                        shouldThrow<OptionalEventException> {
+                            changeAuthorizationProfileResult.authorizationProfileChangedDeferred
+                                .await()
+                        }
+                    }
+                }
+            }
+        }
+    })

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/ChangeAuthorizationTimeProfileTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/ChangeAuthorizationTimeProfileTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.changeAuthorizationTimeProfile
+import com.open200.xesar.connect.extension.changeAuthorizationTimeProfileAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.AuthorizationTimeProfileChanged
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -62,7 +62,8 @@ class ChangeAuthorizationTimeProfileTest :
 
                         client
                             .publishAsync(
-                                Topics.Event.AUTHORIZATION_PROFILE_CREATED, encodeEvent(apiEvent))
+                                Topics.Event.AUTHORIZATION_TIME_PROFILE_CHANGED,
+                                encodeEvent(apiEvent))
                             .await()
                     }
                 }
@@ -70,11 +71,11 @@ class ChangeAuthorizationTimeProfileTest :
                     simulatedBackendReady.await()
 
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
-                        api.subscribeAsync(Topics(Topics.Event.AUTHORIZATION_PROFILE_CREATED))
+                        api.subscribeAsync(Topics(Topics.Event.AUTHORIZATION_TIME_PROFILE_CHANGED))
                             .await()
 
                         val result =
-                            api.changeAuthorizationTimeProfile(
+                            api.changeAuthorizationTimeProfileAsync(
                                     timeProfileId =
                                         UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
                                     timeProfileName = "timeProfileName",

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/ChangeCalendarTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/ChangeCalendarTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.changeCalendar
+import com.open200.xesar.connect.extension.changeCalendarAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.CalendarChanged
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -70,7 +70,7 @@ class ChangeCalendarTest :
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.CALENDAR_CHANGED)).await()
                         val result =
-                            api.changeCalendar(
+                            api.changeCalendarAsync(
                                     UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
                                     "calendarName",
                                     specialDays = listOf(LocalDate.parse("2018-02-25")))

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/ChangeCodingStationTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/ChangeCodingStationTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.changeCodingStation
+import com.open200.xesar.connect.extension.changeCodingStationAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.CodingStationChanged
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -68,7 +68,7 @@ class ChangeCodingStationTest :
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.CODING_STATION_CHANGED)).await()
                         val result =
-                            api.changeCodingStation(
+                            api.changeCodingStationAsync(
                                     UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
                                     "codingStationName")
                                 .await()

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/ChangeInstallationPointTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/ChangeInstallationPointTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.changeInstallationPoint
+import com.open200.xesar.connect.extension.changeInstallationPointAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.InstallationPointChanged
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -70,7 +70,7 @@ class ChangeInstallationPointTest :
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.INSTALLATION_POINT_CHANGED)).await()
                         val result =
-                            api.changeInstallationPoint(
+                            api.changeInstallationPointAsync(
                                     UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
                                     "installation type")
                                 .await()

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/ChangeOfficeModeTimeProfileTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/ChangeOfficeModeTimeProfileTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.changeOfficeModeTimeProfile
+import com.open200.xesar.connect.extension.changeOfficeModeTimeProfileAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.OfficeModeTimeProfileChanged
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -72,7 +72,7 @@ class ChangeOfficeModeTimeProfileTest :
                         api.subscribeAsync(Topics(Topics.Event.OFFICE_MODE_TIME_PROFILE_CHANGED))
                             .await()
                         val result =
-                            api.changeOfficeModeTimeProfile(
+                            api.changeOfficeModeTimeProfileAsync(
                                     UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
                                     "name",
                                     timeSeries = TimeProfileFixture.timeSeries)

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/ChangePersonInformationTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/ChangePersonInformationTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.changePersonInformation
+import com.open200.xesar.connect.extension.changePersonInformationAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.PersonChanged
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -68,7 +68,7 @@ class ChangePersonInformationTest :
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.PERSON_CHANGED)).await()
                         val result =
-                            api.changePersonInformation(
+                            api.changePersonInformationAsync(
                                     firstName = "first name", externalId = "EXT-4711")
                                 .await()
                         result.firstName.shouldBeEqual("first name")

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/ChangeZoneDataTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/ChangeZoneDataTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.changeZoneData
+import com.open200.xesar.connect.extension.changeZoneDataAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.ZoneChanged
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -69,7 +69,7 @@ class ChangeZoneDataTest :
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.ZONE_CHANGED)).await()
                         val result =
-                            api.changeZoneData(
+                            api.changeZoneDataAsync(
                                     "zoneName",
                                     "zoneDescription",
                                     UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/ConfigureAssignableAuthorizationProfilesTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/ConfigureAssignableAuthorizationProfilesTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.configureAssignableAuthorizationProfiles
+import com.open200.xesar.connect.extension.configureAssignableAuthorizationProfilesAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.UserGroupChanged
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -72,7 +72,7 @@ class ConfigureAssignableAuthorizationProfilesTest :
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.USER_GROUP_CHANGED)).await()
                         val result =
-                            api.configureAssignableAuthorizationProfiles(
+                            api.configureAssignableAuthorizationProfilesAsync(
                                     listOf(UUID.fromString("4e6f78d6-51c7-4bc2-a992-78971eecfbda")),
                                     UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
                                 .await()

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/ConfigureManualOfficeModeAndShopModeTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/ConfigureManualOfficeModeAndShopModeTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.configureManualOfficeModeAndShopModeMapi
+import com.open200.xesar.connect.extension.configureManualOfficeModeAndShopModeMapiAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.InstallationPointChanged
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -70,7 +70,7 @@ class ConfigureManualOfficeModeAndShopModeTest :
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.INSTALLATION_POINT_CHANGED)).await()
                         val result =
-                            api.configureManualOfficeModeAndShopModeMapi(
+                            api.configureManualOfficeModeAndShopModeMapiAsync(
                                     shopMode = true,
                                     installationPointId =
                                         UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/ConfigureMediaUpgradeTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/ConfigureMediaUpgradeTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.configureMediaUpgradeMapi
+import com.open200.xesar.connect.extension.configureMediaUpgradeMapiAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.InstallationPointChanged
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -70,7 +70,7 @@ class ConfigureMediaUpgradeTest :
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.INSTALLATION_POINT_CHANGED)).await()
                         val result =
-                            api.configureMediaUpgradeMapi(
+                            api.configureMediaUpgradeMapiAsync(
                                     true, UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
                                 .await()
                         result.upgradeMedia?.shouldBeTrue()

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/ConfigureOfficeModeTimeProfileTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/ConfigureOfficeModeTimeProfileTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.configureOfficeModeTimeProfile
+import com.open200.xesar.connect.extension.configureOfficeModeTimeProfileAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.InstallationPointChanged
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -70,7 +70,7 @@ class ConfigureOfficeModeTimeProfileTest :
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.INSTALLATION_POINT_CHANGED)).await()
                         val result =
-                            api.configureOfficeModeTimeProfile(
+                            api.configureOfficeModeTimeProfileAsync(
                                     null, UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
                                 .await()
                         result.timeProfileId.shouldBeNull()

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/ConfigureReleaseDurationTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/ConfigureReleaseDurationTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.configureReleaseDuration
+import com.open200.xesar.connect.extension.configureReleaseDurationAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.InstallationPointChanged
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -70,7 +70,7 @@ class ConfigureReleaseDurationTest :
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.INSTALLATION_POINT_CHANGED)).await()
                         val result =
-                            api.configureReleaseDuration(
+                            api.configureReleaseDurationAsync(
                                     10, 20, UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
                                 .await()
                         result.releaseDurationShort?.shouldBeEqual(10)

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/CreateAuthorizationProfileTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/CreateAuthorizationProfileTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.createAuthorizationProfile
+import com.open200.xesar.connect.extension.createAuthorizationProfileAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.AuthorizationProfileCreated
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -74,7 +74,7 @@ class CreateAuthorizationProfileTest :
                         api.subscribeAsync(Topics(Topics.Event.AUTHORIZATION_PROFILE_CREATED))
                             .await()
                         val result =
-                            api.createAuthorizationProfile(
+                            api.createAuthorizationProfileAsync(
                                     "authorizationProfile1",
                                     "",
                                     UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/CreateAuthorizationTimeProfileTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/CreateAuthorizationTimeProfileTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.createAuthorizationTimeProfile
+import com.open200.xesar.connect.extension.createAuthorizationTimeProfileAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.AuthorizationTimeProfileCreated
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -75,7 +75,7 @@ class CreateAuthorizationTimeProfileTest :
                         api.subscribeAsync(Topics(Topics.Event.AUTHORIZATION_TIME_PROFILE_CREATED))
                             .await()
                         val result =
-                            api.createAuthorizationTimeProfile(
+                            api.createAuthorizationTimeProfileAsync(
                                     name = "timeProfileName",
                                     timeProfileId =
                                         UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/CreateCalendarTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/CreateCalendarTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.createCalendar
+import com.open200.xesar.connect.extension.createCalendarAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.CalendarCreated
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -72,7 +72,7 @@ class CreateCalendarTest :
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.CALENDAR_CREATED)).await()
                         val result =
-                            api.createCalendar(
+                            api.createCalendarAsync(
                                     "calendarName",
                                     listOf(LocalDate.parse("2018-02-25")),
                                     UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/CreateCodingStationTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/CreateCodingStationTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.createCodingStation
+import com.open200.xesar.connect.extension.createCodingStationAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.CodingStationCreated
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -70,7 +70,7 @@ class CreateCodingStationTest :
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.CODING_STATION_CREATED)).await()
                         val result =
-                            api.createCodingStation(
+                            api.createCodingStationAsync(
                                     name = "coding station name",
                                     codingStationId =
                                         UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/CreateInstallationPointTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/CreateInstallationPointTest.kt
@@ -1,0 +1,526 @@
+package com.open200.xesar.connect.command
+
+import com.open200.xesar.connect.Topics
+import com.open200.xesar.connect.XesarConnect
+import com.open200.xesar.connect.XesarMqttClient
+import com.open200.xesar.connect.exception.OptionalEventException
+import com.open200.xesar.connect.exception.ParsingException
+import com.open200.xesar.connect.exception.RequiredEventException
+import com.open200.xesar.connect.extension.createInstallationPointAsync
+import com.open200.xesar.connect.messages.ApiError
+import com.open200.xesar.connect.messages.ComponentType
+import com.open200.xesar.connect.messages.encodeError
+import com.open200.xesar.connect.messages.event.*
+import com.open200.xesar.connect.messages.query.ComponentStatus
+import com.open200.xesar.connect.testutils.MosquittoContainer
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.common.runBlocking
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.extensions.testcontainers.perProject
+import io.kotest.matchers.equals.shouldBeEqual
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import java.time.LocalDateTime
+import java.util.*
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.launch
+
+class CreateInstallationPointTest :
+    FunSpec({
+        val container = MosquittoContainer.container()
+        val config = MosquittoContainer.config(container)
+        listener(container.perProject())
+        test("create installation point returning no event") {
+            coEvery { config.uuidGenerator.generateId() }
+                .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+            runBlocking {
+                val simulatedBackendReady = CompletableDeferred<Unit>()
+                val commandReceived = CompletableDeferred<String>()
+
+                launch {
+                    XesarMqttClient.connectAsync(config).await().use { client ->
+                        client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                        client.onMessage = { topic, payload ->
+                            when (topic) {
+                                Topics.Command.CREATE_INSTALLATION_POINT -> {
+                                    commandReceived.complete(payload.decodeToString())
+                                }
+                            }
+                        }
+
+                        simulatedBackendReady.complete(Unit)
+
+                        val commandContent = commandReceived.await()
+                        commandContent.shouldBeEqual(
+                            "{\"componentType\":\"Cylinder\",\"aggregateId\":\"2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be\",\"linkedInstallationPoints\":{},\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+                    }
+                }
+                launch {
+                    simulatedBackendReady.await()
+
+                    XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                        api.subscribeAsync(
+                                Topics(
+                                    Topics.Event.INSTALLATION_POINT_CREATED,
+                                    Topics.Event.EVVA_COMPONENT_ADDED))
+                            .await()
+
+                        val createInstallationPointResult =
+                            api.createInstallationPointAsync(
+                                ComponentType.Cylinder,
+                                UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"))
+                        shouldThrow<OptionalEventException> {
+                            createInstallationPointResult.evvaComponentAddedDeferred.await()
+                        }
+                        shouldThrow<RequiredEventException> {
+                            createInstallationPointResult.installationPointCreatedDeferred.await()
+                        }
+                    }
+                }
+            }
+        }
+
+        test("create installation point returning an api error") {
+            coEvery { config.uuidGenerator.generateId() }
+                .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+            runBlocking {
+                val simulatedBackendReady = CompletableDeferred<Unit>()
+                val commandReceived = CompletableDeferred<String>()
+
+                launch {
+                    XesarMqttClient.connectAsync(config).await().use { client ->
+                        client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                        client.onMessage = { topic, payload ->
+                            when (topic) {
+                                Topics.Command.CREATE_INSTALLATION_POINT -> {
+                                    commandReceived.complete(payload.decodeToString())
+                                }
+                            }
+                        }
+
+                        simulatedBackendReady.complete(Unit)
+
+                        val commandContent = commandReceived.await()
+                        commandContent.shouldBe(
+                            "{\"componentType\":\"Cylinder\",\"aggregateId\":\"43edc7cf-80ab-4486-86db-41cda2c7a2cd\",\"linkedInstallationPoints\":{},\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+                        val apiError =
+                            ApiError(
+                                "reason",
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                123)
+
+                        client
+                            .publishAsync(
+                                Topics.Event.error(config.apiProperties.userId),
+                                encodeError(apiError))
+                            .await()
+                    }
+                }
+                launch {
+                    simulatedBackendReady.await()
+
+                    XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                        api.subscribeAsync(
+                                Topics(
+                                    Topics.Event.INSTALLATION_POINT_CREATED,
+                                    Topics.Event.EVVA_COMPONENT_ADDED,
+                                    Topics.Event.error(config.apiProperties.userId)))
+                            .await()
+
+                        val createInstallationPointResult =
+                            api.createInstallationPointAsync(
+                                ComponentType.Cylinder,
+                                UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+
+                        shouldThrow<OptionalEventException> {
+                            createInstallationPointResult.evvaComponentAddedDeferred.await()
+                        }
+                        shouldThrow<RequiredEventException> {
+                            createInstallationPointResult.installationPointCreatedDeferred.await()
+                        }
+
+                        val apiError = createInstallationPointResult.apiErrorDeferred.await()
+                        apiError.get().reason.shouldBe("reason")
+                    }
+                }
+            }
+        }
+
+        test("create installation point returning the required event and an api error") {
+            coEvery { config.uuidGenerator.generateId() }
+                .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+            runBlocking {
+                val simulatedBackendReady = CompletableDeferred<Unit>()
+                val commandReceived = CompletableDeferred<String>()
+
+                launch {
+                    XesarMqttClient.connectAsync(config).await().use { client ->
+                        client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                        client.onMessage = { topic, payload ->
+                            when (topic) {
+                                Topics.Command.CREATE_INSTALLATION_POINT -> {
+                                    commandReceived.complete(payload.decodeToString())
+                                }
+                            }
+                        }
+
+                        simulatedBackendReady.complete(Unit)
+
+                        val commandContent = commandReceived.await()
+                        commandContent.shouldBeEqual(
+                            "{\"componentType\":\"Cylinder\",\"aggregateId\":\"43edc7cf-80ab-4486-86db-41cda2c7a2cd\",\"linkedInstallationPoints\":{},\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+
+                        val apiEvent =
+                            ApiEvent(
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                InstallationPointCreated(
+                                    id = UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd")))
+                        client
+                            .publishAsync(
+                                Topics.Event.INSTALLATION_POINT_CREATED, encodeEvent(apiEvent))
+                            .await()
+
+                        val apiError =
+                            ApiError(
+                                "reason",
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                123)
+
+                        client
+                            .publishAsync(
+                                Topics.Event.error(config.apiProperties.userId),
+                                encodeError(apiError))
+                            .await()
+                    }
+                }
+                launch {
+                    simulatedBackendReady.await()
+
+                    XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                        api.subscribeAsync(
+                                Topics(
+                                    Topics.Event.INSTALLATION_POINT_CREATED,
+                                    Topics.Event.EVVA_COMPONENT_ADDED,
+                                    Topics.Event.error(config.apiProperties.userId)))
+                            .await()
+
+                        val createInstallationPointResult =
+                            api.createInstallationPointAsync(
+                                ComponentType.Cylinder,
+                                UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+                        val installationPointCreated =
+                            createInstallationPointResult.installationPointCreatedDeferred.await()
+                        installationPointCreated.id.shouldBe(
+                            UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+                        val apiError = createInstallationPointResult.apiErrorDeferred.await()
+                        apiError.get().reason.shouldBe("reason")
+                        shouldThrow<OptionalEventException> {
+                            createInstallationPointResult.evvaComponentAddedDeferred.await()
+                        }
+                    }
+                }
+            }
+        }
+
+        test(
+            "create installation point returning the required event and an error event but switch order of events") {
+                coEvery { config.uuidGenerator.generateId() }
+                    .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+                runBlocking {
+                    val simulatedBackendReady = CompletableDeferred<Unit>()
+                    val commandReceived = CompletableDeferred<String>()
+
+                    launch {
+                        XesarMqttClient.connectAsync(config).await().use { client ->
+                            client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                            client.onMessage = { topic, payload ->
+                                when (topic) {
+                                    Topics.Command.CREATE_INSTALLATION_POINT -> {
+                                        commandReceived.complete(payload.decodeToString())
+                                    }
+                                }
+                            }
+
+                            simulatedBackendReady.complete(Unit)
+
+                            val commandContent = commandReceived.await()
+                            commandContent.shouldBeEqual(
+                                "{\"componentType\":\"Cylinder\",\"aggregateId\":\"43edc7cf-80ab-4486-86db-41cda2c7a2cd\",\"linkedInstallationPoints\":{},\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+
+                            val apiError =
+                                ApiError(
+                                    "reason",
+                                    UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
+                                    123)
+
+                            client
+                                .publishAsync(
+                                    Topics.Event.error(config.apiProperties.userId),
+                                    encodeError(apiError))
+                                .await()
+
+                            val apiEvent =
+                                ApiEvent(
+                                    UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                    InstallationPointCreated(
+                                        id =
+                                            UUID.fromString(
+                                                "43edc7cf-80ab-4486-86db-41cda2c7a2cd")))
+                            client
+                                .publishAsync(
+                                    Topics.Event.INSTALLATION_POINT_CREATED, encodeEvent(apiEvent))
+                                .await()
+                        }
+                    }
+                    launch {
+                        simulatedBackendReady.await()
+
+                        XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                            api.subscribeAsync(
+                                    Topics(
+                                        Topics.Event.INSTALLATION_POINT_CREATED,
+                                        Topics.Event.EVVA_COMPONENT_ADDED,
+                                        Topics.Event.error(config.apiProperties.userId)))
+                                .await()
+
+                            val createInstallationPointResult =
+                                api.createInstallationPointAsync(
+                                    ComponentType.Cylinder,
+                                    UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+                            val installationPointCreated =
+                                createInstallationPointResult.installationPointCreatedDeferred
+                                    .await()
+                            installationPointCreated.id.shouldBe(
+                                UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+                            shouldThrow<OptionalEventException> {
+                                createInstallationPointResult.await()
+                            }
+                        }
+                    }
+                }
+            }
+
+        test("add evva component with wrong publish back to get an Exception") {
+            coEvery { config.uuidGenerator.generateId() }
+                .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+            runBlocking {
+                val simulatedBackendReady = CompletableDeferred<Unit>()
+                val commandReceived = CompletableDeferred<String>()
+
+                launch {
+                    XesarMqttClient.connectAsync(config).await().use { client ->
+                        client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                        client.onMessage = { topic, payload ->
+                            when (topic) {
+                                Topics.Command.CREATE_INSTALLATION_POINT -> {
+                                    commandReceived.complete(payload.decodeToString())
+                                }
+                            }
+                        }
+
+                        simulatedBackendReady.complete(Unit)
+
+                        val commandContent = commandReceived.await()
+
+                        commandContent.shouldBeEqual(
+                            "{\"componentType\":\"Cylinder\",\"aggregateId\":\"43edc7cf-80ab-4486-86db-41cda2c7a2cd\",\"linkedInstallationPoints\":{},\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+
+                        val apiEvent2 =
+                            ApiEvent(
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                EvvaComponentAdded(
+                                    id = UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"),
+                                    evvaComponentId =
+                                        UUID.fromString("3a33c05b-133d-4b9d-a496-5d30dfd2d2c3"),
+                                    type = ComponentType.Cylinder,
+                                    stateChangedAt = LocalDateTime.MIN,
+                                    status = ComponentStatus.AssembledPrepared))
+
+                        client
+                            .publishAsync(
+                                Topics.Event.INSTALLATION_POINT_CREATED,
+                                "\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\"" /*encodeEvent(apiEvent)*/)
+                            .await()
+                        logger.info { "sent installation point changed" }
+
+                        client
+                            .publishAsync(Topics.Event.EVVA_COMPONENT_ADDED, encodeEvent(apiEvent2))
+                            .await()
+
+                        logger.info { "sent evva component added" }
+                    }
+                }
+                launch {
+                    simulatedBackendReady.await()
+
+                    XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                        api.subscribeAsync(
+                                Topics(
+                                    Topics.Event.INSTALLATION_POINT_CREATED,
+                                    Topics.Event.EVVA_COMPONENT_ADDED))
+                            .await()
+
+                        val createInstallationPointResult =
+                            api.createInstallationPointAsync(
+                                ComponentType.Cylinder,
+                                UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+
+                        shouldThrow<ParsingException> {
+                            createInstallationPointResult.installationPointCreatedDeferred.await()
+                        }
+                        val evvaComponentAdded =
+                            createInstallationPointResult.evvaComponentAddedDeferred.await()
+                        evvaComponentAdded.type.shouldBe(ComponentType.Cylinder)
+                    }
+                }
+            }
+        }
+
+        test("add evva component returning both events") {
+            coEvery { config.uuidGenerator.generateId() }
+                .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+            runBlocking {
+                val simulatedBackendReady = CompletableDeferred<Unit>()
+                val commandReceived = CompletableDeferred<String>()
+
+                launch {
+                    XesarMqttClient.connectAsync(config).await().use { client ->
+                        client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                        client.onMessage = { topic, payload ->
+                            when (topic) {
+                                Topics.Command.CREATE_INSTALLATION_POINT -> {
+                                    commandReceived.complete(payload.decodeToString())
+                                }
+                            }
+                        }
+
+                        simulatedBackendReady.complete(Unit)
+
+                        val commandContent = commandReceived.await()
+
+                        commandContent.shouldBeEqual(
+                            "{\"componentType\":\"Cylinder\",\"aggregateId\":\"43edc7cf-80ab-4486-86db-41cda2c7a2cd\",\"linkedInstallationPoints\":{},\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+
+                        val apiEvent =
+                            ApiEvent(
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                InstallationPointCreated(
+                                    id = UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd")))
+
+                        val apiEvent2 =
+                            ApiEvent(
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                EvvaComponentAdded(
+                                    id = UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"),
+                                    evvaComponentId =
+                                        UUID.fromString("3a33c05b-133d-4b9d-a496-5d30dfd2d2c3"),
+                                    type = ComponentType.Cylinder,
+                                    stateChangedAt = LocalDateTime.MIN,
+                                    status = ComponentStatus.AssembledPrepared))
+
+                        client
+                            .publishAsync(
+                                Topics.Event.INSTALLATION_POINT_CREATED, encodeEvent(apiEvent))
+                            .await()
+
+                        client
+                            .publishAsync(Topics.Event.EVVA_COMPONENT_ADDED, encodeEvent(apiEvent2))
+                            .await()
+                    }
+                }
+                launch {
+                    simulatedBackendReady.await()
+
+                    XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                        api.subscribeAsync(
+                                Topics(
+                                    Topics.Event.INSTALLATION_POINT_CREATED,
+                                    Topics.Event.EVVA_COMPONENT_ADDED))
+                            .await()
+
+                        val createInstallationPointResult =
+                            api.createInstallationPointAsync(
+                                ComponentType.Cylinder,
+                                UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+                        val test =
+                            createInstallationPointResult.installationPointCreatedDeferred.await()
+                        test.id.shouldBe(UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+                        val evvaComponentAdded =
+                            createInstallationPointResult.evvaComponentAddedDeferred.await()
+                        evvaComponentAdded.type.shouldBe(ComponentType.Cylinder)
+                    }
+                }
+            }
+        }
+
+        test("add evva component but only required field will be returned") {
+            coEvery { config.uuidGenerator.generateId() }
+                .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+            runBlocking {
+                val simulatedBackendReady = CompletableDeferred<Unit>()
+                val commandReceived = CompletableDeferred<String>()
+
+                launch {
+                    XesarMqttClient.connectAsync(config).await().use { client ->
+                        client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                        client.onMessage = { topic, payload ->
+                            when (topic) {
+                                Topics.Command.CREATE_INSTALLATION_POINT -> {
+                                    commandReceived.complete(payload.decodeToString())
+                                }
+                            }
+                        }
+
+                        simulatedBackendReady.complete(Unit)
+
+                        val commandContent = commandReceived.await()
+                        commandContent.shouldBeEqual(
+                            "{\"componentType\":\"Cylinder\",\"aggregateId\":\"43edc7cf-80ab-4486-86db-41cda2c7a2cd\",\"linkedInstallationPoints\":{},\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+
+                        val apiEvent =
+                            ApiEvent(
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                InstallationPointCreated(
+                                    id = UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd")))
+
+                        client
+                            .publishAsync(
+                                Topics.Event.INSTALLATION_POINT_CREATED, encodeEvent(apiEvent))
+                            .await()
+                    }
+                }
+                launch {
+                    simulatedBackendReady.await()
+
+                    XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                        api.subscribeAsync(
+                                Topics(
+                                    Topics.Event.INSTALLATION_POINT_CREATED,
+                                    Topics.Event.EVVA_COMPONENT_ADDED))
+                            .await()
+
+                        val createInstallationPointResult =
+                            api.createInstallationPointAsync(
+                                ComponentType.Cylinder,
+                                UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+
+                        val installationPointCreated =
+                            createInstallationPointResult.installationPointCreatedDeferred.await()
+                        installationPointCreated.id.shouldBe(
+                            UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+
+                        shouldThrow<OptionalEventException> {
+                            createInstallationPointResult.evvaComponentAddedDeferred.await()
+                        }
+                    }
+                }
+            }
+        }
+    })

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/CreateOfficeModeTimeProfileTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/CreateOfficeModeTimeProfileTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.createOfficeModeTimeProfile
+import com.open200.xesar.connect.extension.createOfficeModeTimeProfileAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.OfficeModeTimeProfileCreated
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -75,7 +75,7 @@ class CreateOfficeModeTimeProfileTest :
                         api.subscribeAsync(Topics(Topics.Event.OFFICE_MODE_TIME_PROFILE_CREATED))
                             .await()
                         val result =
-                            api.createOfficeModeTimeProfile(
+                            api.createOfficeModeTimeProfileAsync(
                                     name = "timeProfileName",
                                     timeSeries = TimeProfileFixture.timeSeries,
                                     timeProfileId =

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/CreatePersonTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/CreatePersonTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.createPerson
+import com.open200.xesar.connect.extension.createPersonAsync
 import com.open200.xesar.connect.messages.PersonalLog
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.PersonCreated
@@ -72,7 +72,7 @@ class CreatePersonTest :
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.PERSON_CREATED)).await()
                         val result =
-                            api.createPerson(
+                            api.createPersonAsync(
                                     firstName = "firstName",
                                     lastName = "lastName",
                                     personId =

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/CreateZoneTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/CreateZoneTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.createZone
+import com.open200.xesar.connect.extension.createZoneAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.ZoneCreated
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -70,7 +70,7 @@ class CreateZoneTest :
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.ZONE_CREATED)).await()
                         val result =
-                            api.createZone(
+                            api.createZoneAsync(
                                     name = "zoneName",
                                     zoneId =
                                         UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/DeleteAuthorizationProfileTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/DeleteAuthorizationProfileTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.deleteAuthorizationProfile
+import com.open200.xesar.connect.extension.deleteAuthorizationProfileAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.AuthorizationProfileDeleted
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -70,7 +70,7 @@ class DeleteAuthorizationProfileTest :
                         api.subscribeAsync(Topics(Topics.Event.AUTHORIZATION_PROFILE_DELETED))
                             .await()
                         val result =
-                            api.deleteAuthorizationProfile(
+                            api.deleteAuthorizationProfileAsync(
                                     UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
                                 .await()
                         result.id.shouldBeEqual(

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/DeleteAuthorizationTimeProfileTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/DeleteAuthorizationTimeProfileTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.deleteAuthorizationTimeProfile
+import com.open200.xesar.connect.extension.deleteAuthorizationTimeProfileAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.AuthorizationTimeProfileDeleted
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -69,7 +69,7 @@ class DeleteAuthorizationTimeProfileTest :
                         api.subscribeAsync(Topics(Topics.Event.AUTHORIZATION_TIME_PROFILE_DELETED))
                             .await()
                         val result =
-                            api.deleteAuthorizationTimeProfile(
+                            api.deleteAuthorizationTimeProfileAsync(
                                     UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
                                 .await()
                         result.id.shouldBeEqual(

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/DeleteCalendarTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/DeleteCalendarTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.deleteCalendar
+import com.open200.xesar.connect.extension.deleteCalendarAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.CalendarDeleted
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -66,7 +66,7 @@ class DeleteCalendarTest :
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.CALENDAR_DELETED)).await()
                         val result =
-                            api.deleteCalendar(
+                            api.deleteCalendarAsync(
                                     UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
                                 .await()
                         result.id.shouldBeEqual(

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/DeleteCodingStationTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/DeleteCodingStationTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.deleteCodingStation
+import com.open200.xesar.connect.extension.deleteCodingStationAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.CodingStationDeleted
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -69,7 +69,7 @@ class DeleteCodingStationTest :
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.CODING_STATION_DELETED)).await()
                         val result =
-                            api.deleteCodingStation(
+                            api.deleteCodingStationAsync(
                                     UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
                                 .await()
                         result.id.shouldBeEqual(

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/DeleteInstallationPointTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/DeleteInstallationPointTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.deleteInstallationPoint
+import com.open200.xesar.connect.extension.deleteInstallationPointAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.InstallationPointDeleted
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -71,7 +71,7 @@ class DeleteInstallationPointTest :
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.INSTALLATION_POINT_DELETED)).await()
                         val result =
-                            api.deleteInstallationPoint(
+                            api.deleteInstallationPointAsync(
                                     UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
                                 .await()
                         result.id.shouldBeEqual(

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/DeleteOfficeModeTimeProfileTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/DeleteOfficeModeTimeProfileTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.deleteOfficeModeTimeProfile
+import com.open200.xesar.connect.extension.deleteOfficeModeTimeProfileAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.OfficeModeTimeProfileDeleted
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -69,7 +69,7 @@ class DeleteOfficeModeTimeProfileTest :
                         api.subscribeAsync(Topics(Topics.Event.OFFICE_MODE_TIME_PROFILE_DELETED))
                             .await()
                         val result =
-                            api.deleteOfficeModeTimeProfile(
+                            api.deleteOfficeModeTimeProfileAsync(
                                     UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
                                 )
                                 .await()

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/DeletePersonTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/DeletePersonTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.deletePerson
+import com.open200.xesar.connect.extension.deletePersonAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.PersonDeleted
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -65,7 +65,7 @@ class DeletePersonTest :
 
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.PERSON_DELETED)).await()
-                        val result = api.deletePerson("EXT-123").await()
+                        val result = api.deletePersonAsync("EXT-123").await()
 
                         result.id.shouldBeEqual(
                             UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/DeleteZoneTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/DeleteZoneTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.deleteZone
+import com.open200.xesar.connect.extension.deleteZoneAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.ZoneDeleted
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -68,7 +68,8 @@ class DeleteZoneTest :
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.ZONE_DELETED)).await()
                         val result =
-                            api.deleteZone(UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+                            api.deleteZoneAsync(
+                                    UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
                                 .await()
                         result.id.shouldBeEqual(
                             UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/FindComponentTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/FindComponentTest.kt
@@ -3,8 +3,8 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.exception.HttpErrorException
-import com.open200.xesar.connect.extension.findComponent
+import com.open200.xesar.connect.exception.RequiredEventException
+import com.open200.xesar.connect.extension.findComponentAsync
 import com.open200.xesar.connect.messages.ApiError
 import com.open200.xesar.connect.messages.encodeError
 import com.open200.xesar.connect.messages.event.ApiEvent
@@ -72,8 +72,8 @@ class FindComponentTest :
                     simulatedBackendReady.await()
 
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
-                        shouldThrow<HttpErrorException> {
-                            api.findComponent(
+                        shouldThrow<RequiredEventException> {
+                            api.findComponentAsync(
                                     InstallationPointFixture.installationPointFixture.id, true)
                                 .await()
                         }
@@ -124,7 +124,7 @@ class FindComponentTest :
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.FIND_COMPONENT_PERFORMED)).await()
                         val result =
-                            api.findComponent(
+                            api.findComponentAsync(
                                     InstallationPointFixture.installationPointFixture.id, true)
                                 .await()
 

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/ForceRemoveEvvaComponentTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/ForceRemoveEvvaComponentTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.forceRemoveEvvaComponent
+import com.open200.xesar.connect.extension.forceRemoveEvvaComponentAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.EvvaComponentRemoved
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -75,7 +75,7 @@ class ForceRemoveEvvaComponentTest :
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.EVVA_COMPONENT_REMOVED)).await()
                         val result =
-                            api.forceRemoveEvvaComponent(
+                            api.forceRemoveEvvaComponentAsync(
                                     UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
                                 .await()
                         result.aggregateId.shouldBeEqual(

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/LockMediumTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/LockMediumTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.lockMedium
+import com.open200.xesar.connect.extension.lockMediumAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.MediumLocked
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -69,7 +69,8 @@ class LockMediumTest :
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.MEDIUM_LOCKED)).await()
                         val result =
-                            api.lockMedium(UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+                            api.lockMediumAsync(
+                                    UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
                                 .await()
                         result.mediumIdentifier.shouldBeEqual(123L)
                         result.aggregateId.shouldBeEqual(

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/PrepareRemovalOfEvvaComponentTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/PrepareRemovalOfEvvaComponentTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.prepareRemovalOfEvvaComponent
+import com.open200.xesar.connect.extension.prepareRemovalOfEvvaComponentAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.EvvaComponentRemovalPrepared
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -73,7 +73,7 @@ class PrepareRemovalOfEvvaComponentTest :
                             .await()
 
                         val result =
-                            api.prepareRemovalOfEvvaComponent(
+                            api.prepareRemovalOfEvvaComponentAsync(
                                     UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
                                 .await()
                         result.aggregateId.shouldBeEqual(

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/RemoteDisengagePermanentTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/RemoteDisengagePermanentTest.kt
@@ -3,8 +3,8 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.exception.HttpErrorException
-import com.open200.xesar.connect.extension.executeRemoteDisengagePermanent
+import com.open200.xesar.connect.exception.RequiredEventException
+import com.open200.xesar.connect.extension.executeRemoteDisengagePermanentAsync
 import com.open200.xesar.connect.messages.ApiError
 import com.open200.xesar.connect.messages.encodeError
 import com.open200.xesar.connect.messages.event.ApiEvent
@@ -72,8 +72,8 @@ class RemoteDisengagePermanentTest :
                     simulatedBackendReady.await()
 
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
-                        shouldThrow<HttpErrorException> {
-                            api.executeRemoteDisengagePermanent(
+                        shouldThrow<RequiredEventException> {
+                            api.executeRemoteDisengagePermanentAsync(
                                     InstallationPointFixture.installationPointFixture.id, true)
                                 .await()
                         }
@@ -127,7 +127,7 @@ class RemoteDisengagePermanentTest :
                                 Topics(Topics.Event.REMOTE_DISENGAGE_PERMANENT_PERFORMED))
                             .await()
                         val result =
-                            api.executeRemoteDisengagePermanent(
+                            api.executeRemoteDisengagePermanentAsync(
                                     InstallationPointFixture.installationPointFixture.id, true)
                                 .await()
 

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/RemoteDisengageTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/RemoteDisengageTest.kt
@@ -3,8 +3,8 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.exception.HttpErrorException
-import com.open200.xesar.connect.extension.executeRemoteDisengage
+import com.open200.xesar.connect.exception.RequiredEventException
+import com.open200.xesar.connect.extension.executeRemoteDisengageAsync
 import com.open200.xesar.connect.messages.ApiError
 import com.open200.xesar.connect.messages.encodeError
 import com.open200.xesar.connect.messages.event.*
@@ -70,8 +70,8 @@ class RemoteDisengageTest :
                     simulatedBackendReady.await()
 
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
-                        shouldThrow<HttpErrorException> {
-                            api.executeRemoteDisengage(
+                        shouldThrow<RequiredEventException> {
+                            api.executeRemoteDisengageAsync(
                                     InstallationPointFixture.installationPointFixture.id, true)
                                 .await()
                         }
@@ -123,7 +123,7 @@ class RemoteDisengageTest :
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.REMOTE_DISENGAGE_PERFORMED)).await()
                         val result =
-                            api.executeRemoteDisengage(
+                            api.executeRemoteDisengageAsync(
                                     InstallationPointFixture.installationPointFixture.id, true)
                                 .await()
 

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/RemoveInstallationPointAuthorizationFromMediumTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/RemoveInstallationPointAuthorizationFromMediumTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.removeInstallationPointAuthorizationFromMedium
+import com.open200.xesar.connect.extension.removeInstallationPointAuthorizationFromMediumAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.IndividualAuthorizationsDeleted
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -72,7 +72,7 @@ class RemoveInstallationPointAuthorizationFromMediumTest :
                             .await()
 
                         val result =
-                            api.removeInstallationPointAuthorizationFromMedium(
+                            api.removeInstallationPointAuthorizationFromMediumAsync(
                                     UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
                                     UUID.fromString("8c7128d4-a30f-4aad-b5d2-d7b975c5cf8f"))
                                 .await()

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/RemoveInstallationPointFromZoneTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/RemoveInstallationPointFromZoneTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.removeInstallationPointFromZone
+import com.open200.xesar.connect.extension.removeInstallationPointFromZoneAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.InstallationPointsInZoneChanged
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -63,7 +63,7 @@ class RemoveInstallationPointFromZoneTest :
 
                         client
                             .publishAsync(
-                                Topics.Event.AUTHORIZATION_TIME_PROFILE_CREATED,
+                                Topics.Event.INSTALLATION_POINTS_IN_ZONE_CHANGED,
                                 encodeEvent(apiEvent))
                             .await()
                     }
@@ -72,10 +72,10 @@ class RemoveInstallationPointFromZoneTest :
                     simulatedBackendReady.await()
 
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
-                        api.subscribeAsync(Topics(Topics.Event.AUTHORIZATION_TIME_PROFILE_CREATED))
+                        api.subscribeAsync(Topics(Topics.Event.INSTALLATION_POINTS_IN_ZONE_CHANGED))
                             .await()
                         val result =
-                            api.removeInstallationPointFromZone(
+                            api.removeInstallationPointFromZoneAsync(
                                     UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
                                     UUID.fromString("8c7128d4-a30f-4aad-b5d2-d7b975c5cf8f"))
                                 .await()

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/RemoveZoneAuthorizationFromMediumTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/RemoveZoneAuthorizationFromMediumTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.removeZoneAuthorizationFromMedium
+import com.open200.xesar.connect.extension.removeZoneAuthorizationFromMediumAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.IndividualAuthorizationsDeleted
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -70,7 +70,7 @@ class RemoveZoneAuthorizationFromMediumTest :
                         api.subscribeAsync(Topics(Topics.Event.INDIVIDUAL_AUTHORIZATIONS_DELETED))
                             .await()
                         val result =
-                            api.removeZoneAuthorizationFromMedium(
+                            api.removeZoneAuthorizationFromMediumAsync(
                                     UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
                                     UUID.fromString("8c7128d4-a30f-4aad-b5d2-d7b975c5cf8f"))
                                 .await()

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/RequestAddMediumToInstallationTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/RequestAddMediumToInstallationTest.kt
@@ -1,0 +1,550 @@
+package com.open200.xesar.connect.command
+
+import com.open200.xesar.connect.Topics
+import com.open200.xesar.connect.XesarConnect
+import com.open200.xesar.connect.XesarMqttClient
+import com.open200.xesar.connect.exception.ParsingException
+import com.open200.xesar.connect.exception.RequiredEventException
+import com.open200.xesar.connect.extension.requestToAddMediumToInstallationAsync
+import com.open200.xesar.connect.messages.ApiError
+import com.open200.xesar.connect.messages.encodeError
+import com.open200.xesar.connect.messages.event.*
+import com.open200.xesar.connect.testutils.MosquittoContainer
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.common.runBlocking
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.extensions.testcontainers.perProject
+import io.kotest.matchers.equals.shouldBeEqual
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import java.util.*
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.launch
+
+class RequestAddMediumToInstallationTest :
+    FunSpec({
+        val container = MosquittoContainer.container()
+        val config = MosquittoContainer.config(container)
+        listener(container.perProject())
+        test("request add medium to installation returning no event") {
+            coEvery { config.uuidGenerator.generateId() }
+                .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+            runBlocking {
+                val simulatedBackendReady = CompletableDeferred<Unit>()
+                val commandReceived = CompletableDeferred<String>()
+
+                launch {
+                    XesarMqttClient.connectAsync(config).await().use { client ->
+                        client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                        client.onMessage = { topic, payload ->
+                            when (topic) {
+                                Topics.Command.REQUEST_ADD_MEDIUM_TO_INSTALLATION -> {
+                                    commandReceived.complete(payload.decodeToString())
+                                }
+                            }
+                        }
+                        simulatedBackendReady.complete(Unit)
+
+                        val commandContent = commandReceived.await()
+                        commandContent.shouldBeEqual(
+                            "{\"hardwareId\":\"hardwareId\",\"id\":\"2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be\",\"terminalId\":\"43edc7cf-80ab-4486-86db-41cda2c7a2cd\",\"label\":null,\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+                    }
+                }
+                launch {
+                    simulatedBackendReady.await()
+
+                    XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                        api.subscribeAsync(
+                                Topics(
+                                    Topics.Event.ADD_MEDIUM_TO_INSTALLATION_REQUESTED,
+                                    Topics.Event.MEDIUM_ADDED_TO_INSTALLATION))
+                            .await()
+
+                        val requestToAddMediumToInstallationResult =
+                            api.requestToAddMediumToInstallationAsync(
+                                UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"),
+                                "hardwareId",
+                                UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+                        shouldThrow<RequiredEventException> {
+                            requestToAddMediumToInstallationResult
+                                .addMediumToInstallationRequestedDeferred
+                                .await()
+                        }
+                        shouldThrow<RequiredEventException> {
+                            requestToAddMediumToInstallationResult.mediumAddedToInstallationDeferred
+                                .await()
+                        }
+                    }
+                }
+            }
+        }
+
+        test("request add medium to installation returning an api error") {
+            coEvery { config.uuidGenerator.generateId() }
+                .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+            runBlocking {
+                val simulatedBackendReady = CompletableDeferred<Unit>()
+                val commandReceived = CompletableDeferred<String>()
+
+                launch {
+                    XesarMqttClient.connectAsync(config).await().use { client ->
+                        client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                        client.onMessage = { topic, payload ->
+                            when (topic) {
+                                Topics.Command.REQUEST_ADD_MEDIUM_TO_INSTALLATION -> {
+                                    commandReceived.complete(payload.decodeToString())
+                                }
+                            }
+                        }
+
+                        simulatedBackendReady.complete(Unit)
+
+                        val commandContent = commandReceived.await()
+                        commandContent.shouldBe(
+                            "{\"hardwareId\":\"hardwareId\",\"id\":\"2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be\",\"terminalId\":\"43edc7cf-80ab-4486-86db-41cda2c7a2cd\",\"label\":null,\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+                        val apiError =
+                            ApiError(
+                                "reason",
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                123)
+
+                        client
+                            .publishAsync(
+                                Topics.Event.error(config.apiProperties.userId),
+                                encodeError(apiError))
+                            .await()
+                    }
+                }
+                launch {
+                    simulatedBackendReady.await()
+
+                    XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                        api.subscribeAsync(
+                                Topics(
+                                    Topics.Event.ADD_MEDIUM_TO_INSTALLATION_REQUESTED,
+                                    Topics.Event.MEDIUM_ADDED_TO_INSTALLATION,
+                                    Topics.Event.error(config.apiProperties.userId)))
+                            .await()
+
+                        val requestToAddMediumToInstallationResult =
+                            api.requestToAddMediumToInstallationAsync(
+                                UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"),
+                                "hardwareId",
+                                UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+
+                        shouldThrow<RequiredEventException> {
+                            requestToAddMediumToInstallationResult
+                                .addMediumToInstallationRequestedDeferred
+                                .await()
+                        }
+                        shouldThrow<RequiredEventException> {
+                            requestToAddMediumToInstallationResult.mediumAddedToInstallationDeferred
+                                .await()
+                        }
+
+                        val apiError =
+                            requestToAddMediumToInstallationResult.apiErrorDeferred.await()
+                        apiError.get().reason.shouldBe("reason")
+                    }
+                }
+            }
+        }
+
+        test("request add medium to installation returning an required event and an error event") {
+            coEvery { config.uuidGenerator.generateId() }
+                .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+            runBlocking {
+                val simulatedBackendReady = CompletableDeferred<Unit>()
+                val commandReceived = CompletableDeferred<String>()
+
+                launch {
+                    XesarMqttClient.connectAsync(config).await().use { client ->
+                        client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                        client.onMessage = { topic, payload ->
+                            when (topic) {
+                                Topics.Command.REQUEST_ADD_MEDIUM_TO_INSTALLATION -> {
+                                    commandReceived.complete(payload.decodeToString())
+                                }
+                            }
+                        }
+
+                        simulatedBackendReady.complete(Unit)
+
+                        val commandContent = commandReceived.await()
+                        commandContent.shouldBeEqual(
+                            "{\"hardwareId\":\"hardwareId\",\"id\":\"2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be\",\"terminalId\":\"43edc7cf-80ab-4486-86db-41cda2c7a2cd\",\"label\":null,\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+
+                        val apiEvent =
+                            ApiEvent(
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                AddMediumToInstallationRequested(
+                                    aggregateId =
+                                        UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be")))
+                        client
+                            .publishAsync(
+                                Topics.Event.ADD_MEDIUM_TO_INSTALLATION_REQUESTED,
+                                encodeEvent(apiEvent))
+                            .await()
+
+                        val apiError =
+                            ApiError(
+                                "reason",
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                123)
+
+                        client
+                            .publishAsync(
+                                Topics.Event.error(config.apiProperties.userId),
+                                encodeError(apiError))
+                            .await()
+                    }
+                }
+                launch {
+                    simulatedBackendReady.await()
+
+                    XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                        api.subscribeAsync(
+                                Topics(
+                                    Topics.Event.ADD_MEDIUM_TO_INSTALLATION_REQUESTED,
+                                    Topics.Event.MEDIUM_ADDED_TO_INSTALLATION,
+                                    Topics.Event.error(config.apiProperties.userId)))
+                            .await()
+
+                        val requestToAddMediumToInstallationResult =
+                            api.requestToAddMediumToInstallationAsync(
+                                UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"),
+                                "hardwareId",
+                                UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+                        val addMediumToInstallationRequested =
+                            requestToAddMediumToInstallationResult
+                                .addMediumToInstallationRequestedDeferred
+                                .await()
+                        addMediumToInstallationRequested.aggregateId.shouldBe(
+                            UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"))
+                        val apiError =
+                            requestToAddMediumToInstallationResult.apiErrorDeferred.await()
+                        apiError.get().reason.shouldBe("reason")
+                        shouldThrow<RequiredEventException> {
+                            requestToAddMediumToInstallationResult.mediumAddedToInstallationDeferred
+                                .await()
+                        }
+                    }
+                }
+            }
+        }
+
+        test(
+            "request add medium to installation returning the required event and an error event but switch order of events") {
+                coEvery { config.uuidGenerator.generateId() }
+                    .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+                runBlocking {
+                    val simulatedBackendReady = CompletableDeferred<Unit>()
+                    val commandReceived = CompletableDeferred<String>()
+
+                    launch {
+                        XesarMqttClient.connectAsync(config).await().use { client ->
+                            client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                            client.onMessage = { topic, payload ->
+                                when (topic) {
+                                    Topics.Command.REQUEST_ADD_MEDIUM_TO_INSTALLATION -> {
+                                        commandReceived.complete(payload.decodeToString())
+                                    }
+                                }
+                            }
+
+                            simulatedBackendReady.complete(Unit)
+
+                            val commandContent = commandReceived.await()
+                            commandContent.shouldBeEqual(
+                                "{\"hardwareId\":\"hardwareId\",\"id\":\"2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be\",\"terminalId\":\"43edc7cf-80ab-4486-86db-41cda2c7a2cd\",\"label\":null,\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+
+                            val apiError =
+                                ApiError(
+                                    "reason",
+                                    UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
+                                    123)
+
+                            client
+                                .publishAsync(
+                                    Topics.Event.error(config.apiProperties.userId),
+                                    encodeError(apiError))
+                                .await()
+
+                            val apiEvent =
+                                ApiEvent(
+                                    UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                    AddMediumToInstallationRequested(
+                                        aggregateId =
+                                            UUID.fromString(
+                                                "2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be")))
+                            client
+                                .publishAsync(
+                                    Topics.Event.ADD_MEDIUM_TO_INSTALLATION_REQUESTED,
+                                    encodeEvent(apiEvent))
+                                .await()
+                        }
+                    }
+                    launch {
+                        simulatedBackendReady.await()
+
+                        XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                            api.subscribeAsync(
+                                    Topics(
+                                        Topics.Event.ADD_MEDIUM_TO_INSTALLATION_REQUESTED,
+                                        Topics.Event.MEDIUM_ADDED_TO_INSTALLATION,
+                                        Topics.Event.error(config.apiProperties.userId)))
+                                .await()
+
+                            val requestToAddMediumToInstallationResult =
+                                api.requestToAddMediumToInstallationAsync(
+                                    UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"),
+                                    "hardwareId",
+                                    UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+                            val addMediumToInstallationRequested =
+                                requestToAddMediumToInstallationResult
+                                    .addMediumToInstallationRequestedDeferred
+                                    .await()
+                            addMediumToInstallationRequested.aggregateId.shouldBe(
+                                UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"))
+                            shouldThrow<RequiredEventException> {
+                                requestToAddMediumToInstallationResult.await()
+                            }
+                        }
+                    }
+                }
+            }
+
+        test("request add medium to installation with wrong publish back to get an Exception") {
+            coEvery { config.uuidGenerator.generateId() }
+                .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+            runBlocking {
+                val simulatedBackendReady = CompletableDeferred<Unit>()
+                val commandReceived = CompletableDeferred<String>()
+
+                launch {
+                    XesarMqttClient.connectAsync(config).await().use { client ->
+                        client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                        client.onMessage = { topic, payload ->
+                            when (topic) {
+                                Topics.Command.REQUEST_ADD_MEDIUM_TO_INSTALLATION -> {
+                                    commandReceived.complete(payload.decodeToString())
+                                }
+                            }
+                        }
+
+                        simulatedBackendReady.complete(Unit)
+
+                        val commandContent = commandReceived.await()
+
+                        commandContent.shouldBeEqual(
+                            "{\"hardwareId\":\"hardwareId\",\"id\":\"2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be\",\"terminalId\":\"43edc7cf-80ab-4486-86db-41cda2c7a2cd\",\"label\":null,\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+
+                        val apiEvent2 =
+                            ApiEvent(
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                MediumAddedToInstallation(
+                                    aggregateId =
+                                        UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"),
+                                    "hardwareId"))
+
+                        client
+                            .publishAsync(
+                                Topics.Event.ADD_MEDIUM_TO_INSTALLATION_REQUESTED,
+                                "\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\"" /*encodeEvent(apiEvent)*/)
+                            .await()
+
+                        client
+                            .publishAsync(
+                                Topics.Event.MEDIUM_ADDED_TO_INSTALLATION, encodeEvent(apiEvent2))
+                            .await()
+                    }
+                }
+                launch {
+                    simulatedBackendReady.await()
+
+                    XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                        api.subscribeAsync(
+                                Topics(
+                                    Topics.Event.ADD_MEDIUM_TO_INSTALLATION_REQUESTED,
+                                    Topics.Event.MEDIUM_ADDED_TO_INSTALLATION))
+                            .await()
+
+                        val requestToAddMediumToInstallationResult =
+                            api.requestToAddMediumToInstallationAsync(
+                                UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"),
+                                "hardwareId",
+                                UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+
+                        shouldThrow<ParsingException> {
+                            requestToAddMediumToInstallationResult
+                                .addMediumToInstallationRequestedDeferred
+                                .await()
+                        }
+                        val evvaComponentAdded =
+                            requestToAddMediumToInstallationResult.mediumAddedToInstallationDeferred
+                                .await()
+                        evvaComponentAdded.hardwareId.shouldBe("hardwareId")
+                    }
+                }
+            }
+        }
+
+        test("request add medium to installation returning both events") {
+            coEvery { config.uuidGenerator.generateId() }
+                .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+            runBlocking {
+                val simulatedBackendReady = CompletableDeferred<Unit>()
+                val commandReceived = CompletableDeferred<String>()
+
+                launch {
+                    XesarMqttClient.connectAsync(config).await().use { client ->
+                        client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                        client.onMessage = { topic, payload ->
+                            when (topic) {
+                                Topics.Command.REQUEST_ADD_MEDIUM_TO_INSTALLATION -> {
+                                    commandReceived.complete(payload.decodeToString())
+                                }
+                            }
+                        }
+
+                        simulatedBackendReady.complete(Unit)
+
+                        val commandContent = commandReceived.await()
+
+                        commandContent.shouldBeEqual(
+                            "{\"hardwareId\":\"hardwareId\",\"id\":\"2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be\",\"terminalId\":\"43edc7cf-80ab-4486-86db-41cda2c7a2cd\",\"label\":null,\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+
+                        val apiEvent =
+                            ApiEvent(
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                AddMediumToInstallationRequested(
+                                    aggregateId =
+                                        UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
+                                    hardwareId = "hardwareId"))
+
+                        val apiEvent2 =
+                            ApiEvent(
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                MediumAddedToInstallation(
+                                    aggregateId =
+                                        UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"),
+                                    "hardwareId"))
+
+                        client
+                            .publishAsync(
+                                Topics.Event.ADD_MEDIUM_TO_INSTALLATION_REQUESTED,
+                                encodeEvent(apiEvent))
+                            .await()
+
+                        client
+                            .publishAsync(
+                                Topics.Event.MEDIUM_ADDED_TO_INSTALLATION, encodeEvent(apiEvent2))
+                            .await()
+                    }
+                }
+                launch {
+                    simulatedBackendReady.await()
+
+                    XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                        api.subscribeAsync(
+                                Topics(
+                                    Topics.Event.ADD_MEDIUM_TO_INSTALLATION_REQUESTED,
+                                    Topics.Event.MEDIUM_ADDED_TO_INSTALLATION))
+                            .await()
+
+                        val requestToAddMediumToInstallationResult =
+                            api.requestToAddMediumToInstallationAsync(
+                                UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"),
+                                "hardwareId",
+                                UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+                        val mediumAddedToInstallation =
+                            requestToAddMediumToInstallationResult.mediumAddedToInstallationDeferred
+                                .await()
+                        mediumAddedToInstallation.aggregateId.shouldBe(
+                            UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"))
+                        val addMediumToInstallationRequested =
+                            requestToAddMediumToInstallationResult
+                                .addMediumToInstallationRequestedDeferred
+                                .await()
+                        addMediumToInstallationRequested.hardwareId.shouldBe("hardwareId")
+                    }
+                }
+            }
+        }
+
+        test("request add medium to installation but only one required field will be returned") {
+            coEvery { config.uuidGenerator.generateId() }
+                .returns(UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"))
+            runBlocking {
+                val simulatedBackendReady = CompletableDeferred<Unit>()
+                val commandReceived = CompletableDeferred<String>()
+
+                launch {
+                    XesarMqttClient.connectAsync(config).await().use { client ->
+                        client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
+
+                        client.onMessage = { topic, payload ->
+                            when (topic) {
+                                Topics.Command.REQUEST_ADD_MEDIUM_TO_INSTALLATION -> {
+                                    commandReceived.complete(payload.decodeToString())
+                                }
+                            }
+                        }
+
+                        simulatedBackendReady.complete(Unit)
+
+                        val commandContent = commandReceived.await()
+                        commandContent.shouldBeEqual(
+                            "{\"hardwareId\":\"hardwareId\",\"id\":\"2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be\",\"terminalId\":\"43edc7cf-80ab-4486-86db-41cda2c7a2cd\",\"label\":null,\"commandId\":\"00000000-1281-40ae-89d7-5c541d77a757\",\"token\":\"JDJhJDEwJDFSNEljZ2FaRUNXUXBTQ25XN05KbE9qRzFHQ1VjMzkvWTBVcFpZb1M4Vmt0dnJYZ0tJVFBx\"}")
+
+                        val apiEvent =
+                            ApiEvent(
+                                UUID.fromString("00000000-1281-40ae-89d7-5c541d77a757"),
+                                AddMediumToInstallationRequested(
+                                    aggregateId =
+                                        UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be")))
+
+                        client
+                            .publishAsync(
+                                Topics.Event.ADD_MEDIUM_TO_INSTALLATION_REQUESTED,
+                                encodeEvent(apiEvent))
+                            .await()
+                    }
+                }
+                launch {
+                    simulatedBackendReady.await()
+
+                    XesarConnect.connectAndLoginAsync(config).await().use { api ->
+                        api.subscribeAsync(
+                                Topics(
+                                    Topics.Event.ADD_MEDIUM_TO_INSTALLATION_REQUESTED,
+                                    Topics.Event.MEDIUM_ADDED_TO_INSTALLATION))
+                            .await()
+
+                        val requestToAddMediumToInstallationResult =
+                            api.requestToAddMediumToInstallationAsync(
+                                UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"),
+                                "hardwareId",
+                                UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
+                        val addMediumToInstallationRequested =
+                            requestToAddMediumToInstallationResult
+                                .addMediumToInstallationRequestedDeferred
+                                .await()
+                        addMediumToInstallationRequested.aggregateId.shouldBe(
+                            UUID.fromString("2d52bd95-18ba-4e46-8f00-0fc4c1e3f9be"))
+
+                        shouldThrow<RequiredEventException> {
+                            requestToAddMediumToInstallationResult.mediumAddedToInstallationDeferred
+                                .await()
+                        }
+                    }
+                }
+            }
+        }
+    })

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/RevertPrepareRemovalOfEvvaComponentTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/RevertPrepareRemovalOfEvvaComponentTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.revertPrepareRemovalOfEvvaComponent
+import com.open200.xesar.connect.extension.revertPrepareRemovalOfEvvaComponentAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.PrepareEvvaComponentRemovalReverted
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -72,7 +72,7 @@ class RevertPrepareRemovalOfEvvaComponentTest :
                                 Topics(Topics.Event.PREPARE_EVVA_COMPONENT_REMOVAL_REVERTED))
                             .await()
                         val result =
-                            api.revertPrepareRemovalOfEvvaComponent(
+                            api.revertPrepareRemovalOfEvvaComponentAsync(
                                     UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
                                 )
                                 .await()

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/SetAccessBeginAtTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/SetAccessBeginAtTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.setAccessBeginAt
+import com.open200.xesar.connect.extension.setAccessBeginAtAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.MediumChanged
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -70,7 +70,7 @@ class SetAccessBeginAtTest :
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.MEDIUM_CHANGED)).await()
                         val result =
-                            api.setAccessBeginAt(
+                            api.setAccessBeginAtAsync(
                                     UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
                                     LocalDateTime.parse("2023-08-24T16:25:52.225991"))
                                 .await()

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/SetAccessEndAtTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/SetAccessEndAtTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.setAccessEndAt
+import com.open200.xesar.connect.extension.setAccessEndAtAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.MediumChanged
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -70,7 +70,7 @@ class SetAccessEndAtTest :
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.MEDIUM_CHANGED)).await()
                         val result =
-                            api.setAccessEndAt(
+                            api.setAccessEndAtAsync(
                                     UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
                                     LocalDateTime.parse("2023-08-24T16:25:52.225991"))
                                 .await()

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/SetDailySchedulerExecutionTimeTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/SetDailySchedulerExecutionTimeTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.setDailySchedulerExecutionTime
+import com.open200.xesar.connect.extension.setDailySchedulerExecutionTimeAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.PartitionChanged
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -13,6 +13,7 @@ import io.kotest.common.runBlocking
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.extensions.testcontainers.perProject
 import io.kotest.matchers.equals.shouldBeEqual
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import java.util.*
 import kotlinx.coroutines.CompletableDeferred
@@ -58,7 +59,7 @@ class SetDailySchedulerExecutionTimeTest :
                                     dailySchedulerExecutionTime = TimeProfileFixture.localTime))
 
                         client
-                            .publishAsync(Topics.Event.MEDIUM_CHANGED, encodeEvent(apiEvent))
+                            .publishAsync(Topics.Event.PARTITION_CHANGED, encodeEvent(apiEvent))
                             .await()
                     }
                 }
@@ -66,11 +67,11 @@ class SetDailySchedulerExecutionTimeTest :
                     simulatedBackendReady.await()
 
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
-                        api.subscribeAsync(Topics(Topics.Event.MEDIUM_CHANGED)).await()
+                        api.subscribeAsync(Topics(Topics.Event.PARTITION_CHANGED)).await()
                         val result =
-                            api.setDailySchedulerExecutionTime(TimeProfileFixture.localTime).await()
-                        result.dailySchedulerExecutionTime?.shouldBeEqual(
-                            TimeProfileFixture.localTime)
+                            api.setDailySchedulerExecutionTimeAsync(TimeProfileFixture.localTime)
+                                .await()
+                        result.dailySchedulerExecutionTime.shouldBe(TimeProfileFixture.localTime)
                     }
                 }
             }

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/SetDefaultAuthorizationProfileForPersonTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/SetDefaultAuthorizationProfileForPersonTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.setDefaultAuthorizationProfileForPerson
+import com.open200.xesar.connect.extension.setDefaultAuthorizationProfileForPersonAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.PersonChanged
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -69,7 +69,8 @@ class SetDefaultAuthorizationProfileForPersonTest :
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.PERSON_CHANGED)).await()
                         val result =
-                            api.setDefaultAuthorizationProfileForPerson("EXT-123", null).await()
+                            api.setDefaultAuthorizationProfileForPersonAsync("EXT-123", null)
+                                .await()
                         result.id.shouldBeEqual(
                             UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
                     }

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/SetDefaultDisengagePeriodForPersonTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/SetDefaultDisengagePeriodForPersonTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.setDefaultDisengagePeriodForPerson
+import com.open200.xesar.connect.extension.setDefaultDisengagePeriodForPersonAsync
 import com.open200.xesar.connect.messages.DisengagePeriod
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.PersonChanged
@@ -70,7 +70,8 @@ class SetDefaultDisengagePeriodForPersonTest :
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.PERSON_CHANGED)).await()
                         val result =
-                            api.setDefaultDisengagePeriodForPerson("EXT-123", DisengagePeriod.SHORT)
+                            api.setDefaultDisengagePeriodForPersonAsync(
+                                    "EXT-123", DisengagePeriod.SHORT)
                                 .await()
                         result.id.shouldBeEqual(
                             UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/SetDefaultValidityDurationTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/SetDefaultValidityDurationTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.setDefaultValidityDuration
+import com.open200.xesar.connect.extension.setDefaultValidityDurationAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.PartitionChanged
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -66,7 +66,7 @@ class SetDefaultValidityDurationTest :
 
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.PARTITION_CHANGED)).await()
-                        val result = api.setDefaultValidityDuration(0).await()
+                        val result = api.setDefaultValidityDurationAsync(0).await()
                         result.id.shouldBeEqual(
                             UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
                         result.validityDuration?.shouldBeEqual(0)

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/SetDisengagePeriodOnMediumTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/SetDisengagePeriodOnMediumTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.setDisengagePeriodOnMedium
+import com.open200.xesar.connect.extension.setDisengagePeriodOnMediumAsync
 import com.open200.xesar.connect.messages.DisengagePeriod
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.MediumChanged
@@ -70,7 +70,7 @@ class SetDisengagePeriodOnMediumTest :
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.MEDIUM_CHANGED)).await()
                         val result =
-                            api.setDisengagePeriodOnMedium(
+                            api.setDisengagePeriodOnMediumAsync(
                                     UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
                                     DisengagePeriod.LONG)
                                 .await()

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/SetInstallationPointPersonalReferenceDurationTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/SetInstallationPointPersonalReferenceDurationTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.setInstallationPointPersonalReferenceDuration
+import com.open200.xesar.connect.extension.setInstallationPointPersonalReferenceDurationAsync
 import com.open200.xesar.connect.messages.PersonalLog
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.PartitionChanged
@@ -70,7 +70,7 @@ class SetInstallationPointPersonalReferenceDurationTest :
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.PARTITION_CHANGED)).await()
                         val result =
-                            api.setInstallationPointPersonalReferenceDuration(
+                            api.setInstallationPointPersonalReferenceDurationAsync(
                                     PersonalLog(days = 30))
                                 .await()
                         result.id.shouldBeEqual(

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/SetLabelOnMediumTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/SetLabelOnMediumTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.setLabelOnMedium
+import com.open200.xesar.connect.extension.setLabelOnMediumAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.MediumChanged
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -69,7 +69,7 @@ class SetLabelOnMediumTest :
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.MEDIUM_CHANGED)).await()
                         val result =
-                            api.setLabelOnMedium(
+                            api.setLabelOnMediumAsync(
                                     UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
                                     "label")
                                 .await()

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/SetPersonPersonalReferenceDurationTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/SetPersonPersonalReferenceDurationTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.setPersonPersonalReferenceDuration
+import com.open200.xesar.connect.extension.setPersonPersonalReferenceDurationAsync
 import com.open200.xesar.connect.messages.PersonalLog
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.PartitionChanged
@@ -59,7 +59,7 @@ class SetPersonPersonalReferenceDurationTest :
                                         PersonalLog(days = 30)))
 
                         client
-                            .publishAsync(Topics.Event.MEDIUM_CHANGED, encodeEvent(apiEvent))
+                            .publishAsync(Topics.Event.PARTITION_CHANGED, encodeEvent(apiEvent))
                             .await()
                     }
                 }
@@ -67,9 +67,10 @@ class SetPersonPersonalReferenceDurationTest :
                     simulatedBackendReady.await()
 
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
-                        api.subscribeAsync(Topics(Topics.Event.MEDIUM_CHANGED)).await()
+                        api.subscribeAsync(Topics(Topics.Event.PARTITION_CHANGED)).await()
                         val result =
-                            api.setPersonPersonalReferenceDuration(PersonalLog(days = 30)).await()
+                            api.setPersonPersonalReferenceDurationAsync(PersonalLog(days = 30))
+                                .await()
                         result.id.shouldBeEqual(
                             UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
                         result.personDefaultPersonalReferenceDuration?.days?.shouldBeEqual(30)

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/SetPersonalReferenceDurationForInstallationPointTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/SetPersonalReferenceDurationForInstallationPointTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.setPersonalReferenceDurationForInstallationPoint
+import com.open200.xesar.connect.extension.setPersonalReferenceDurationForInstallationPointAsync
 import com.open200.xesar.connect.messages.PersonalLog
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.InstallationPointChanged
@@ -74,7 +74,7 @@ class SetPersonalReferenceDurationForInstallationPointTest :
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.INSTALLATION_POINT_CHANGED)).await()
                         val result =
-                            api.setPersonalReferenceDurationForInstallationPoint(
+                            api.setPersonalReferenceDurationForInstallationPointAsync(
                                     UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"),
                                     PersonalLog(
                                         days = 30,

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/SetPersonalReferenceDurationInPersonTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/SetPersonalReferenceDurationInPersonTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.setPersonalReferenceDurationInPerson
+import com.open200.xesar.connect.extension.setPersonalReferenceDurationInPersonAsync
 import com.open200.xesar.connect.messages.PersonalLog
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.PersonChanged
@@ -70,7 +70,7 @@ class SetPersonalReferenceDurationInPersonTest :
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.PERSON_CHANGED)).await()
                         val result =
-                            api.setPersonalReferenceDurationInPerson(
+                            api.setPersonalReferenceDurationInPersonAsync(
                                     "EXT-123", PersonalLog(days = 30))
                                 .await()
                         result.id.shouldBeEqual(

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/SetReplacementMediumDurationTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/SetReplacementMediumDurationTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.setReplacementMediumDuration
+import com.open200.xesar.connect.extension.setReplacementMediumDurationAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.PartitionChanged
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -66,7 +66,7 @@ class SetReplacementMediumDurationTest :
 
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.PARTITION_CHANGED)).await()
-                        val result = api.setReplacementMediumDuration(123).await()
+                        val result = api.setReplacementMediumDurationAsync(123).await()
                         result.id.shouldBeEqual(
                             UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
                         result.replacementMediumDuration?.shouldBeEqual(123)

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/SetValidityDurationTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/SetValidityDurationTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.setValidityDuration
+import com.open200.xesar.connect.extension.setValidityDurationAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.MediumChanged
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -69,7 +69,7 @@ class SetValidityDurationTest :
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.MEDIUM_CHANGED)).await()
                         val result =
-                            api.setValidityDuration(
+                            api.setValidityDurationAsync(
                                     UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"), 123)
                                 .await()
                         result.id.shouldBeEqual(

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/SetValidityThresholdTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/SetValidityThresholdTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.setValidityThreshold
+import com.open200.xesar.connect.extension.setValidityThresholdAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.PartitionChanged
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -66,7 +66,7 @@ class SetValidityThresholdTest :
 
                     XesarConnect.connectAndLoginAsync(config).await().use { api ->
                         api.subscribeAsync(Topics(Topics.Event.PARTITION_CHANGED)).await()
-                        val result = api.setValidityThreshold(123).await()
+                        val result = api.setValidityThresholdAsync(123).await()
                         result.id.shouldBeEqual(
                             UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"))
                         result.validityDuration?.shouldBeEqual(123)

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/WithdrawAuthorizationProfileFromMediumTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/command/WithdrawAuthorizationProfileFromMediumTest.kt
@@ -3,7 +3,7 @@ package com.open200.xesar.connect.command
 import com.open200.xesar.connect.Topics
 import com.open200.xesar.connect.XesarConnect
 import com.open200.xesar.connect.XesarMqttClient
-import com.open200.xesar.connect.extension.withdrawAuthorizationProfileFromMedium
+import com.open200.xesar.connect.extension.withdrawAuthorizationProfileFromMediumAsync
 import com.open200.xesar.connect.messages.event.ApiEvent
 import com.open200.xesar.connect.messages.event.AuthorizationProfileWithdrawnFromMedium
 import com.open200.xesar.connect.messages.event.encodeEvent
@@ -74,7 +74,7 @@ class WithdrawAuthorizationProfileFromMediumTest :
                                 Topics(Topics.Event.AUTHORIZATION_PROFILE_WITHDRAWN_FROM_MEDIUM))
                             .await()
                         val result =
-                            api.withdrawAuthorizationProfileFromMedium(
+                            api.withdrawAuthorizationProfileFromMediumAsync(
                                     UUID.fromString("43edc7cf-80ab-4486-86db-41cda2c7a2cd"), null)
                                 .await()
                         result.id.shouldBeEqual(

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/query/QueryIdentificationMediumTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/query/QueryIdentificationMediumTest.kt
@@ -166,7 +166,7 @@ class QueryIdentificationMediumTest :
                         XesarMqttClient.connectAsync(config).await().use { client ->
                             client.subscribeAsync(arrayOf(Topics.ALL_TOPICS)).await()
 
-                            client.onMessage = { topic, payload ->
+                            client.onMessage = { topic, _ ->
                                 when (topic) {
                                     Topics.Query.REQUEST -> {
                                         queryReceived.complete(null)

--- a/xesar-connect/src/test/kotlin/com/open200/xesar/connect/query/QueryTimeProfileTest.kt
+++ b/xesar-connect/src/test/kotlin/com/open200/xesar/connect/query/QueryTimeProfileTest.kt
@@ -80,8 +80,8 @@ class QueryTimeProfileTest :
                             .await()
                         val result = api.queryTimeProfileListAsync().await()
                         result.totalCount.shouldBeEqual(2)
-                        result.data[0].name.shouldBeEqual("name")
-                        result.data[1].name.shouldBeEqual("name 2")
+                        result.data[0].name?.shouldBeEqual("name")
+                        result.data[1].name?.shouldBeEqual("name 2")
                     }
                 }
             }
@@ -114,7 +114,7 @@ class QueryTimeProfileTest :
                             QueryTestHelper.createQueryRequest(
                                 TimeProfile.QUERY_RESOURCE,
                                 requestId,
-                                TimeProfileFixture.timeProfileFixture.id))
+                                TimeProfileFixture.timeProfileFixture.id!!))
 
                         val person =
                             encodeQueryElement(
@@ -131,10 +131,11 @@ class QueryTimeProfileTest :
                         api.subscribeAsync(Topics(Topics.Query.result(config.apiProperties.userId)))
                             .await()
                         val result =
-                            api.queryTimeProfileByIdAsync(TimeProfileFixture.timeProfileFixture.id)
+                            api.queryTimeProfileByIdAsync(
+                                    TimeProfileFixture.timeProfileFixture.id!!)
                                 .await()
-                        result.id.shouldBeEqual(TimeProfileFixture.timeProfileFixture.id)
-                        result.name.shouldBeEqual("name")
+                        result.id?.shouldBeEqual(TimeProfileFixture.timeProfileFixture.id!!)
+                        result.name?.shouldBeEqual("name")
                     }
                 }
             }


### PR DESCRIPTION
Add missing convenience methods for commands returning two or three events. 
The difficulty of this task was how to resolve the problem that we do not know if all of the 2 or all of the 3 events are returned when sending a command as some events are optional.