### PR TITLE
build: remove old OSSRH publishing method and use a temporary worfklow

### DIFF
--- a/xesar-connect/build.gradle.kts
+++ b/xesar-connect/build.gradle.kts
@@ -76,6 +76,8 @@ java {
     withSourcesJar()
 }
 
+val publishDirPath = layout.buildDirectory.dir("xesar-connect-artifact")
+
 publishing {
     publications {
         create<MavenPublication>("library") {
@@ -107,13 +109,19 @@ publishing {
             from(components["java"])
         }
     }
-    repositories {
-        maven {
-            name = "Sonatype"
-            url = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
-            credentials(PasswordCredentials::class)
-        }
-    }
+    repositories { maven { url = uri(publishDirPath) } }
+}
+
+tasks.register<Zip>("zipArtifact") {
+    description = "Creates a zip archive containing the xesar-connect artifact."
+    group = "publishing"
+    destinationDirectory.set(layout.buildDirectory)
+    from(publishDirPath)
+}
+
+tasks.register("prepareMavenPublish") {
+    dependsOn(setOf("publish", "zipArtifact"))
+    group = "publishing"
 }
 
 signing { sign(publishing.publications["library"]) }


### PR DESCRIPTION
Since Maven Central deprecated the OSSRH publishing method, we've adopted a temporary workflow for publishing artifacts to their new Central Portal. While an official Gradle plugin isn't yet available, we use the existing Maven plugin to build and package the artifact within a zip archive. For deployment, we currently utilize a manual process involving a curl command or direct upload to the Central Portal. This interim solution will be replaced with an official plugin once it becomes available.