### PR TITLE
resolve version mismatch by downgrading Ktor

### DIFF
--- a/xesar-connect/build.gradle.kts
+++ b/xesar-connect/build.gradle.kts
@@ -25,7 +25,7 @@ repositories {
     mavenCentral()
 }
 
-val ktorVersion: String = "3.1.1"
+val ktorVersion: String = "2.3.13"
 val kotlinxVersion: String = "1.10.1"
 val kotlinLoggingVersion: String = "3.0.5"
 val kotestVersion: String = "5.9.1"


### PR DESCRIPTION
xesarconnect 2.0.0 was compiled with kotlinx.serialization 1.8.0, but Spring Boot Gradle Plugin 3.4.2 forces version 1.6.3 at runtime, causing serialization errors. Downgraded Ktor to ensure compatibility with Spring Boot Gradle Plugin's kotlinx.serialization version.